### PR TITLE
Derive report name from output name if available

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -1718,13 +1718,14 @@ def acquire_target(target: Target, args: argparse.Namespace, output_ts: Optional
             **collection_report_serialized,
         }
 
-        report_output_dir = output_path if output_path.is_dir() else output_path.parent
-        report_file_path = persist_execution_report(
-            output_dir=report_output_dir,
-            prefix=target.name,
-            timestamp=output_ts,
-            report_data=execution_report,
-        )
+        if args.output.is_dir():
+            report_file_name = format_output_name(target.name, postfix=output_ts, ext="report.json")
+        else:
+            report_file_name = f"{output_path.name}.report.json"
+
+        report_file_path = output_path.parent / report_file_name
+        persist_execution_report(report_file_path, execution_report)
+
         files.append(report_file_path)
         log.info("Acquisition report for %s is written to %s", target, report_file_path)
 

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -370,15 +370,12 @@ def get_formatted_exception() -> str:
 def format_output_name(prefix, postfix=None, ext=None):
     if not postfix:
         postfix = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
-    name = "{}_{}".format(prefix, postfix)
+    name = f"{prefix}_{postfix}"
     if ext:
-        name = "{}.{}".format(name, ext)
+        name = f"{name}.{ext}"
     return name
 
 
-def persist_execution_report(output_dir: Path, prefix: str, timestamp: str, report_data: dict) -> Path:
-    report_filename = format_output_name(prefix, postfix=timestamp, ext="report.json")
-    report_full_path = output_dir / report_filename
-    with open(report_full_path, "w") as f:
+def persist_execution_report(path: Path, report_data: dict) -> Path:
+    with open(path, "w") as f:
         f.write(json.dumps(report_data, sort_keys=True, indent=4))
-    return report_full_path


### PR DESCRIPTION
Fixes #45 

Specifying `-o /tmp` will use the same old behaviour, e.g. result in `/tmp/DESKTOP-46R9IUD_20230316170910.report.json`. Specifying `-o /tmp/test.tar` will instead result in `/tmp/test.tar.report.json`. Dealing with the possible extra extension will be hard because you don't necessarily know if it should be part of the file name (e.g. extension left out, but filename contains an AD domain). Checking for common extensions seems a bit overkill for this.