### PR TITLE
Acquire the alternative data streams for SDS and usnjrnl

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -313,11 +313,10 @@ class NTFS(Module):
 
     @classmethod
     def collect_usnjrnl(cls, collector: Collector, fs, name: str) -> None:
-        usnjrnl_path = fs.path("$Extend/$Usnjrnl")
-
         try:
+            usnjrnl_path = fs.path("$Extend/$Usnjrnl:$J")
             entry = usnjrnl_path.get()
-            journal = entry.entry.open("$J")
+            journal = entry.open()
 
             i = 0
             while journal.runlist[i][0] is None:
@@ -344,10 +343,10 @@ class NTFS(Module):
 
     @classmethod
     def collect_ntfs_secure(cls, collector: Collector, fs, name: str) -> None:
-        secure_path = fs.path("$Secure")
         try:
+            secure_path = fs.path("$Secure:$SDS")
             entry = secure_path.get()
-            sds = entry.entry.open("$SDS")
+            sds = entry.open()
             collector.output.write(
                 f"{collector.base}/{name}/$Secure:$SDS",
                 sds,


### PR DESCRIPTION
In #33 there was a change to the tarloader that allows the collection of volatile data. This code uses lstat() to get some properties of the file that is collected, however it fails on ntfs files that only have alternative data streams and no main data stream (e.g. $Secure). 

When explicitly getting the alternate data stream as a file entry (using e.g. $Secure:$SDS), the properties of the entry are set correctly and lstat() will work.

(DIS-1911)
