### PR TITLE
Skip mount points when collecting a directory

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -272,7 +272,7 @@ class Sys(Module):
         target.filesystems.add(sysfs)
         target.fs.mount("/sys", sysfs)
 
-        collector.collect(spec, follow=False, volatile=True)
+        collector.collect(spec, follow=False, volatile=True, skip_mounts=False)
 
 
 @register_module("--proc")
@@ -293,7 +293,7 @@ class Proc(Module):
         target.filesystems.add(procfs)
         target.fs.mount("/proc", procfs)
 
-        collector.collect(spec, follow=False, volatile=True)
+        collector.collect(spec, follow=False, volatile=True, skip_mounts=False)
 
 
 @register_module("-n", "--ntfs")


### PR DESCRIPTION
When collecting a directory or glob, any subdirectories within that
directory or within directories expanded from the glob, that are also
mount points, will be skipped.

(DIS-1785)