### PR TITLE
Prevent collection of acquire's own output files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock
+
+import pytest
+from dissect.target import Target
+from dissect.target.filesystem import VirtualFile, VirtualFilesystem, VirtualSymlink
+
+
+@pytest.fixture
+def mock_file() -> Mock:
+    return Mock()
+
+
+@pytest.fixture
+def mock_fs(mock_file) -> VirtualFilesystem:
+    fs = VirtualFilesystem(case_sensitive=False)
+    fs.makedirs("/foo/bar")
+    fs.map_file_entry("/foo/bar/some-file", VirtualFile(fs, "some-file", mock_file))
+    fs.map_file_entry("/foo/bar/own-file", VirtualFile(fs, "own-file", mock_file))
+    fs.map_file_entry("/foo/bar/some-symlink", VirtualSymlink(fs, "some-symlink", "/foo/bar/some-file"))
+    fs.map_file_entry("/foo/own-symlink", VirtualSymlink(fs, "own-symlink", "/foo/bar/own-file"))
+    return fs
+
+
+@pytest.fixture
+def mock_target(mock_fs) -> Target:
+    target = Target()
+    target.fs.mount("/", mock_fs)
+    target.filesystems.add(mock_fs)
+    target.os = "mock"
+    return target


### PR DESCRIPTION
In certain circumstances acquire can encounter its own output files, collecting them is not desired. These are currently the log file and output tar file or output directory.

This can happen in a number of cases:

- devtmpfs is mounted somewhere under /var, some of te symlinks under /dev/fd will point to the acquire files,
- acquire is executed from one of the directories that will be collected and the output directory is not changed from the default,
- the output directory is set to a (sub-)drictory that will be collected.

(DIS-1785)