### PR TITLE
Add Browser history to Linux (full profile)

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -1881,6 +1881,7 @@ PROFILES = {
             Etc,
             Boot,
             Home,
+            History,
             Var,
         ],
         "bsd": [


### PR DESCRIPTION
The module contains browser history paths found on Linux distributions, but the module is not used by any Linux profile 

* https://github.com/fox-it/acquire/blob/main/acquire/acquire.py#L1106-L1150
* https://github.com/fox-it/acquire/blob/main/acquire/acquire.py#L1215-L1244