### PR TITLE
Add User Group Policy path

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -855,6 +855,7 @@ class Misc(Module):
         ("dir", "sysvol/windows/sysvol/domain/policies/"),
         ("dir", "sysvol/windows/system32/GroupPolicy/DataStore/"),
         ("dir", "sysvol/ProgramData/Microsoft/Group Policy/History/"),
+        ("dir", "AppData/Local/Microsoft/Group Policy/History/", from_user_home),
         ("glob", "sysvol/Windows/System32/LogFiles/SUM/*.mdb"),
     ]
 


### PR DESCRIPTION
For a user policy setting, the database is stored in the following location: `C:\Users%username%\AppData\Local\Microsoft\Group Policy\History`

https://learn.microsoft.com/en-us/troubleshoot/windows-server/group-policy/remove-this-item-if-it-is-no-longer-applied-option