### PR TITLE
Add Linux symbol table file

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -1365,6 +1365,7 @@ class Boot(Module):
         ("glob", "/boot/efi*"),
         ("glob", "/boot/grub*"),
         ("glob", "/boot/init*"),
+        ("glob", "/boot/system*"),
     ]
 
 


### PR DESCRIPTION
The file can be used to create a Volatility Linux profile, in case dwarfdump is also executed on the target or a system with the same distribution, kernel version and CPU architecture