### PR TITLE
Add OSX DHCP settings

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -1501,6 +1501,8 @@ class OSX(Module):
         ("file", "/System/Library/CoreServices/SystemVersion.plist"),
         # system preferences
         ("dir", "/Library/Preferences"),
+        # DHCP settings
+        ("dir", "/private/var/db/dhcpclient/leases"),
     ]
 
 


### PR DESCRIPTION
Used by Dissect Target to find configured IP-addresses.
https://github.com/fox-it/dissect.target/blob/b6ea46e2ed95321440df6c8c6b65803af06da859/dissect/target/plugins/os/unix/bsd/osx/_os.py#L50-L56