### PR TITLE
Add --skip-parent argument

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -2250,11 +2250,13 @@ def acquire_children_and_targets(target: Target, args: argparse.Namespace) -> No
 
     log.info("")
 
-    try:
-        files = acquire_target(target, args, args.start_time)
-    except Exception:
-        log.exception("Failed to acquire target")
-        raise
+    files = []
+    if (args.children and not args.skip_parent) or not args.children:
+        try:
+            files.extend(acquire_target(target, args, args.start_time))
+        except Exception:
+            log.exception("Failed to acquire target")
+            raise
 
     if args.children:
         for child in target.list_children():

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -287,6 +287,9 @@ def check_and_set_acquire_args(
         setattr(args, "cagent_key", args.config.get("cagent_key"))
         setattr(args, "cagent_certificate", args.config.get("cagent_certificate"))
 
+    if not args.children and args.skip_parent:
+        raise ValueError("--skip-parent can only be set with --children")
+
 
 def get_user_name() -> str:
     try:

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -95,6 +95,7 @@ def create_argument_parser(profiles: dict, modules: dict) -> argparse.ArgumentPa
         action="store_true",
         help="collect all children in addition to main target",
     )
+    parser.add_argument("--skip-parent", action="store_true", help="skip parent collection (when using --children)")
 
     parser.add_argument(
         "--force-fallback",


### PR DESCRIPTION
Allows for skipping parent collection when running with `--children`.