### PR TITLE
Provide PyOxidizer binaries

### DIFF
--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -27,9 +27,8 @@ jobs:
             ~/.cargo/git/db/
           key: linux-cache
 
-      # We need target-query to build the plugin list, let acquire determine which version to pull in
       - name: Install dependencies
-        run: /opt/python/cp39-cp39/bin/pip install pyoxidizer acquire==${{ github.event.inputs.tag }}
+        run: /opt/python/cp39-cp39/bin/pip install pyoxidizer dissect
 
       - name: Build binary
         run: |
@@ -84,9 +83,8 @@ jobs:
       - name: Install forked PyOxidizer
         run: cargo install --git https://github.com/Schamper/pyoxidizer pyoxidizer --force --locked
 
-      # We need target-query to build the plugin list, let acquire determine which version to pull in
       - name: Install dependencies
-        run: /opt/python/cp39-cp39/bin/pip install acquire==${{ github.event.inputs.tag }}
+        run: /opt/python/cp39-cp39/bin/pip install dissect
 
       - name: Build binary
         run: |
@@ -123,9 +121,8 @@ jobs:
         with:
           python-version: '3.9'
 
-      # We need target-query to build the plugin list, let acquire determine which version to pull in
       - name: Install dependencies
-        run: pip install pyoxidizer acquire==${{ github.event.inputs.tag }}
+        run: pip install pyoxidizer dissect
 
       - name: Build binary
         run: |
@@ -162,9 +159,8 @@ jobs:
         with:
           python-version: '3.9'
 
-      # We need target-query to build the plugin list, let acquire determine which version to pull in
       - name: Install dependencies
-        run: pip install pyoxidizer acquire==${{ github.event.inputs.tag }}
+        run: pip install pyoxidizer dissect
 
       - name: Build binary
         run: |

--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -1,0 +1,180 @@
+name: Build PyOxidizer Binary
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build-linux-gnu:
+    name: Build Linux (GNU)
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux2014_x86_64
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pyoxidizer/
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: linux-cache
+
+      - name: Install dependencies
+        run: /opt/python/cp39-cp39/bin/pip install pyoxidizer dissect.target
+
+      - name: Build binary
+        run: |
+          mkdir -p build/lib/dissect/target/plugins
+          /opt/python/cp39-cp39/bin/target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
+          /opt/python/cp39-cp39/bin/pyoxidizer build --release --target-triple x86_64-unknown-linux-gnu --var flavor standalone
+          strip build/x86_64-unknown-linux-gnu/release/install/acquire
+
+      - name: Verify binary
+        run: build/x86_64-unknown-linux-gnu/release/install/acquire --version
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acquire-linux
+          path: build/x86_64-unknown-linux-gnu/release/install/*
+
+  build-linux-musl:
+    name: Build Linux (musl)
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux2014_x86_64
+    env:
+      musl_version: 1.2.4
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+          echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pyoxidizer/
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: linux-musl-cache
+
+      - name: Setup musl
+        run: |
+          curl -L https://www.musl-libc.org/releases/musl-${{ env.musl_version }}.tar.gz | tar -xzf -
+          cd musl-*
+          ./configure --exec-prefix=/usr/local
+          make
+          make install
+
+      - name: Install forked PyOxidizer
+        run: cargo install --git https://github.com/Schamper/pyoxidizer pyoxidizer --force --locked
+
+      - name: Install dependencies
+        run: /opt/python/cp39-cp39/bin/pip install dissect.target
+
+      - name: Build binary
+        run: |
+          mkdir -p build/lib/dissect/target/plugins
+          /opt/python/cp39-cp39/bin/target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
+          pyoxidizer build --release --target-triple x86_64-unknown-linux-musl --var flavor standalone
+          strip build/x86_64-unknown-linux-musl/release/install/acquire
+
+      - name: Verify binary
+        run: build/x86_64-unknown-linux-musl/release/install/acquire --version
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acquire-linux-musl
+          path: build/x86_64-unknown-linux-musl/release/install/*
+
+  build-windows:
+    name: Build Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Local\pyoxidizer\
+            ~\.cargo\bin\
+            ~\.cargo\registry\index\
+            ~\.cargo\registry\cache\
+            ~\.cargo\git\db\
+          key: windows-cache
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: pip install pyoxidizer dissect.target
+
+      - name: Build binary
+        run: |
+          mkdir -p build/lib/dissect/target/plugins
+          target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
+          pyoxidizer build --release --target-triple x86_64-pc-windows-msvc --var flavor standalone_static
+          strip build/x86_64-pc-windows-msvc/release/install/acquire.exe
+
+      - name: Verify binary
+        run: build/x86_64-pc-windows-msvc/release/install/acquire.exe --version
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acquire-windows
+          path: build/x86_64-pc-windows-msvc/release/install/*
+
+  build-macos:
+    name: Build macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/pyoxidizer/
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: macos-cache
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: pip install pyoxidizer dissect.target
+
+      - name: Build binary
+        run: |
+          mkdir -p build/lib/dissect/target/plugins
+          target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
+          pyoxidizer build --release --target-triple x86_64-apple-darwin --var flavor standalone
+          pyoxidizer build --release --target-triple aarch64-apple-darwin --var flavor standalone
+
+          mkdir -p build/universal2-apple-darwin/release/install
+          cp -r build/x86_64-apple-darwin/release/install/* build/universal2-apple-darwin/release/install/
+          lipo -create build/x86_64-apple-darwin/release/install/acquire build/aarch64-apple-darwin/release/install/acquire -output build/universal2-apple-darwin/release/install/acquire
+          strip build/universal2-apple-darwin/release/install/acquire
+
+      - name: Verify binary
+        run: build/universal2-apple-darwin/release/install/acquire --version
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acquire-macos
+          path: build/universal2-apple-darwin/release/install/*

--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -81,7 +81,7 @@ jobs:
           make install
 
       - name: Install forked PyOxidizer
-        run: cargo install --git https://github.com/Schamper/pyoxidizer pyoxidizer --force --locked
+        run: cargo install --git https://github.com/fox-it/pyoxidizer --branch esxi-compatibility pyoxidizer --force --locked
 
       - name: Install dependencies
         run: /opt/python/cp39-cp39/bin/pip install dissect

--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -38,7 +38,7 @@ jobs:
           strip build/x86_64-unknown-linux-gnu/release/install/acquire
 
       - name: Verify binary
-        run: build/x86_64-unknown-linux-gnu/release/install/acquire --version
+        run: build/x86_64-unknown-linux-gnu/release/install/acquire-x86_64-unknown-linux-gnu --help
 
       - uses: actions/upload-artifact@v3
         with:
@@ -94,7 +94,7 @@ jobs:
           strip build/x86_64-unknown-linux-musl/release/install/acquire
 
       - name: Verify binary
-        run: build/x86_64-unknown-linux-musl/release/install/acquire --version
+        run: build/x86_64-unknown-linux-musl/release/install/acquire-x86_64-unknown-linux-musl --help
 
       - uses: actions/upload-artifact@v3
         with:
@@ -132,7 +132,7 @@ jobs:
           strip build/x86_64-pc-windows-msvc/release/install/acquire.exe
 
       - name: Verify binary
-        run: build/x86_64-pc-windows-msvc/release/install/acquire.exe --version
+        run: build/x86_64-pc-windows-msvc/release/install/acquire-x86_64-pc-windows-msvc.exe --help
 
       - uses: actions/upload-artifact@v3
         with:
@@ -171,11 +171,11 @@ jobs:
 
           mkdir -p build/universal2-apple-darwin/release/install
           cp -r build/x86_64-apple-darwin/release/install/* build/universal2-apple-darwin/release/install/
-          lipo -create build/x86_64-apple-darwin/release/install/acquire build/aarch64-apple-darwin/release/install/acquire -output build/universal2-apple-darwin/release/install/acquire
-          strip build/universal2-apple-darwin/release/install/acquire
+          lipo -create build/x86_64-apple-darwin/release/install/acquire build/aarch64-apple-darwin/release/install/acquire -output build/universal2-apple-darwin/release/install/acquire-universal2-apple-darwin
+          strip build/universal2-apple-darwin/release/install/acquire-universal2-apple-darwin
 
       - name: Verify binary
-        run: build/universal2-apple-darwin/release/install/acquire --version
+        run: build/universal2-apple-darwin/release/install/acquire-universal2-apple-darwin --help
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -1,9 +1,10 @@
 name: Build PyOxidizer Binary
 on:
-  push:
-    tags:
-      - '*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to build
+        required: true
 
 jobs:
   build-linux-gnu:
@@ -12,6 +13,8 @@ jobs:
     container: quay.io/pypa/manylinux2014_x86_64
 
     steps:
+      # We use older versions of the checkout and cache actions, those work with the LIBC version of this container
+      # We also can't use the setup-python action for this reason - it depends on a newer LIBC
       - uses: actions/checkout@v3
 
       - uses: actions/cache@v3
@@ -24,14 +27,15 @@ jobs:
             ~/.cargo/git/db/
           key: linux-cache
 
+      # We need target-query to build the plugin list, let acquire determine which version to pull in
       - name: Install dependencies
-        run: /opt/python/cp39-cp39/bin/pip install pyoxidizer dissect.target
+        run: /opt/python/cp39-cp39/bin/pip install pyoxidizer acquire==${{ github.event.inputs.tag }}
 
       - name: Build binary
         run: |
           mkdir -p build/lib/dissect/target/plugins
           /opt/python/cp39-cp39/bin/target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
-          /opt/python/cp39-cp39/bin/pyoxidizer build --release --target-triple x86_64-unknown-linux-gnu --var flavor standalone
+          /opt/python/cp39-cp39/bin/pyoxidizer build --release --target-triple x86_64-unknown-linux-gnu --var flavor standalone --var version ${{ github.event.inputs.tag }}
           strip build/x86_64-unknown-linux-gnu/release/install/acquire
 
       - name: Verify binary
@@ -50,6 +54,8 @@ jobs:
       musl_version: 1.2.4
 
     steps:
+      # We use older versions of the checkout and cache actions, those work with the LIBC version of this container
+      # We also can't use the setup-python action for this reason - it depends on a newer LIBC
       - uses: actions/checkout@v3
 
       - name: Setup Rust
@@ -78,14 +84,15 @@ jobs:
       - name: Install forked PyOxidizer
         run: cargo install --git https://github.com/Schamper/pyoxidizer pyoxidizer --force --locked
 
+      # We need target-query to build the plugin list, let acquire determine which version to pull in
       - name: Install dependencies
-        run: /opt/python/cp39-cp39/bin/pip install dissect.target
+        run: /opt/python/cp39-cp39/bin/pip install acquire==${{ github.event.inputs.tag }}
 
       - name: Build binary
         run: |
           mkdir -p build/lib/dissect/target/plugins
           /opt/python/cp39-cp39/bin/target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
-          pyoxidizer build --release --target-triple x86_64-unknown-linux-musl --var flavor standalone
+          pyoxidizer build --release --target-triple x86_64-unknown-linux-musl --var flavor standalone --var version ${{ github.event.inputs.tag }}
           strip build/x86_64-unknown-linux-musl/release/install/acquire
 
       - name: Verify binary
@@ -116,14 +123,15 @@ jobs:
         with:
           python-version: '3.9'
 
+      # We need target-query to build the plugin list, let acquire determine which version to pull in
       - name: Install dependencies
-        run: pip install pyoxidizer dissect.target
+        run: pip install pyoxidizer acquire==${{ github.event.inputs.tag }}
 
       - name: Build binary
         run: |
           mkdir -p build/lib/dissect/target/plugins
           target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
-          pyoxidizer build --release --target-triple x86_64-pc-windows-msvc --var flavor standalone_static
+          pyoxidizer build --release --target-triple x86_64-pc-windows-msvc --var flavor standalone_static --var version ${{ github.event.inputs.tag }}
           strip build/x86_64-pc-windows-msvc/release/install/acquire.exe
 
       - name: Verify binary
@@ -154,15 +162,16 @@ jobs:
         with:
           python-version: '3.9'
 
+      # We need target-query to build the plugin list, let acquire determine which version to pull in
       - name: Install dependencies
-        run: pip install pyoxidizer dissect.target
+        run: pip install pyoxidizer acquire==${{ github.event.inputs.tag }}
 
       - name: Build binary
         run: |
           mkdir -p build/lib/dissect/target/plugins
           target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
-          pyoxidizer build --release --target-triple x86_64-apple-darwin --var flavor standalone
-          pyoxidizer build --release --target-triple aarch64-apple-darwin --var flavor standalone
+          pyoxidizer build --release --target-triple x86_64-apple-darwin --var flavor standalone --var version ${{ github.event.inputs.tag }}
+          pyoxidizer build --release --target-triple aarch64-apple-darwin --var flavor standalone --var version ${{ github.event.inputs.tag }}
 
           mkdir -p build/universal2-apple-darwin/release/install
           cp -r build/x86_64-apple-darwin/release/install/* build/universal2-apple-darwin/release/install/

--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -57,8 +57,6 @@ jobs:
           curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
           echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
 
-      - uses: Swatinem/rust-cache@v2
-
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -28,13 +28,13 @@ jobs:
           key: linux-cache
 
       - name: Install dependencies
-        run: /opt/python/cp39-cp39/bin/pip install pyoxidizer dissect
+        run: /opt/python/cp310-cp310/bin/pip install pyoxidizer dissect
 
       - name: Build binary
         run: |
           mkdir -p build/lib/dissect/target/plugins
-          /opt/python/cp39-cp39/bin/target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
-          /opt/python/cp39-cp39/bin/pyoxidizer build --release --target-triple x86_64-unknown-linux-gnu --var flavor standalone --var version ${{ github.event.inputs.tag }}
+          /opt/python/cp310-cp310/bin/target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
+          /opt/python/cp310-cp310/bin/pyoxidizer build --release --target-triple x86_64-unknown-linux-gnu --var flavor standalone --var version ${{ github.event.inputs.tag }}
           strip build/x86_64-unknown-linux-gnu/release/install/acquire
 
       - name: Verify binary
@@ -84,12 +84,12 @@ jobs:
         run: cargo install --git https://github.com/fox-it/pyoxidizer --branch esxi-compatibility pyoxidizer --force --locked
 
       - name: Install dependencies
-        run: /opt/python/cp39-cp39/bin/pip install dissect
+        run: /opt/python/cp310-cp310/bin/pip install dissect
 
       - name: Build binary
         run: |
           mkdir -p build/lib/dissect/target/plugins
-          /opt/python/cp39-cp39/bin/target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
+          /opt/python/cp310-cp310/bin/target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
           pyoxidizer build --release --target-triple x86_64-unknown-linux-musl --var flavor standalone --var version ${{ github.event.inputs.tag }}
           strip build/x86_64-unknown-linux-musl/release/install/acquire
 
@@ -119,7 +119,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: pip install pyoxidizer dissect
@@ -157,7 +157,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: pip install pyoxidizer dissect

--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -75,7 +75,6 @@ except ImportError:
     CONFIG = defaultdict(lambda: None)
 
 
-VERSION = version
 ACQUIRE_BANNER = rf"""
                        _
   __ _  ___ __ _ _   _(_)_ __ ___

--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -42,6 +42,7 @@ from acquire.uploaders.minio import MinIO
 from acquire.uploaders.plugin import UploaderPlugin, upload_files_using_uploader
 from acquire.uploaders.plugin_registry import UploaderRegistry
 from acquire.utils import (
+    VERSION,
     check_and_set_acquire_args,
     check_and_set_log_args,
     create_argument_parser,
@@ -57,18 +58,12 @@ from acquire.utils import (
 )
 
 try:
-    from acquire.version import version
-except ImportError:
-    version = "0.0.dev"
-
-try:
     # Injected by pystandalone builder
     from acquire.config import CONFIG
 except ImportError:
     CONFIG = defaultdict(lambda: None)
 
 
-VERSION = version
 ACQUIRE_BANNER = r"""
                        _
   __ _  ___ __ _ _   _(_)_ __ ___

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -17,6 +17,11 @@ from dissect.target import Target
 from acquire.outputs import OUTPUTS
 from acquire.uploaders.plugin_registry import UploaderRegistry
 
+try:
+    from acquire.version import version as VERSION
+except ImportError:
+    VERSION = "0.0.dev"
+
 # Acquire Configuration for CAgent and TargetD
 CAGENT_TARGETD_ATTRS = {
     "cagent_key",
@@ -148,6 +153,7 @@ def create_argument_parser(profiles: dict, modules: dict) -> argparse.ArgumentPa
             parser.add_argument(*args, **kwargs)
 
     parser.add_argument("-v", "--verbose", action="count", default=3, help="increase output verbosity")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {VERSION}")
     return parser
 
 

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -1,5 +1,5 @@
 def make_exe():
-    dist = default_python_distribution(flavor=VARS["flavor"])
+    dist = default_python_distribution(flavor=VARS["flavor"], python_version="3.10")
 
     policy = dist.make_python_packaging_policy()
     policy.bytecode_optimize_level_two = True
@@ -12,7 +12,7 @@ def make_exe():
     python_config.run_module = "acquire.acquire"
 
     exe = dist.to_python_executable(
-        name="acquire",
+        name="acquire-" + BUILD_TARGET_TRIPLE,
         packaging_policy=policy,
         config=python_config,
     )
@@ -30,6 +30,7 @@ def make_exe():
         "dissect.hypervisor",
         "dissect.ntfs",
         "dissect.regf",
+        "dissect.sql",
         "dissect.squashfs",
         "dissect.target",
         "dissect.util",

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -39,6 +39,9 @@ def make_exe():
         "minio",
     ]
 
+    # If you want to build acquire from the local source directory, uncomment this and remove "acquire" from pip_args
+    # exe.add_python_resources(exe.read_package_root(CWD, ["acquire"]))
+
     # Lie about our platform to get cross-compilation to work (msgpack fails to download otherwise)
     if BUILD_TARGET_TRIPLE == "x86_64-pc-windows-msvc":
         pip_args += ["--platform", "win_amd64"]

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -1,0 +1,103 @@
+def make_exe():
+    dist = default_python_distribution(flavor=VARS["flavor"])
+
+    policy = dist.make_python_packaging_policy()
+    policy.bytecode_optimize_level_two = True
+    policy.file_scanner_classify_files = True
+    policy.resources_location = "in-memory"
+
+    python_config = dist.make_python_interpreter_config()
+    python_config.oxidized_importer = True
+    python_config.filesystem_importer = False
+    python_config.run_module = "acquire.acquire"
+
+    exe = dist.to_python_executable(
+        name="acquire",
+        packaging_policy=policy,
+        config=python_config,
+    )
+    exe.windows_runtime_dlls_mode = "when-present"
+
+    # The default dependency list of acquire doesn't include enough, and full includes some that are hard to package
+    pip_args = [
+        "acquire",
+        "dissect.cstruct",
+        "dissect.eventlog",
+        "dissect.evidence",
+        "dissect.extfs",
+        "dissect.fat",
+        "dissect.ffs",
+        "dissect.hypervisor",
+        "dissect.ntfs",
+        "dissect.regf",
+        "dissect.squashfs",
+        "dissect.target",
+        "dissect.util",
+        "dissect.vmfs",
+        "dissect.volume",
+        "dissect.xfs",
+        "minio",
+    ]
+
+    # Lie about our platform to get cross-compilation to work (msgpack fails to download otherwise)
+    if BUILD_TARGET_TRIPLE == "x86_64-pc-windows-msvc":
+        pip_args += ["--platform", "win_amd64"]
+    elif BUILD_TARGET_TRIPLE == "i686-pc-windows-msvc":
+        pip_args += ["--platform", "win32"]
+    elif BUILD_TARGET_TRIPLE == "x86_64-unknown-linux-musl":
+        pip_args += ["--platform", "manylinux2014_x86_64"]
+
+    # Use pip_download for all the dependencies
+    for resource in exe.pip_download(pip_args):
+        # Discard msgpack's extension, it has a pure Python fallback
+        if resource.name == "msgpack._cmsgpack":
+            continue
+
+        # The crypto portions of minio aren't needed for normal usage
+        if resource.name == "_cffi_backend" or resource.name.startswith("_argon2_cffi_bindings"):
+            continue
+
+        # Discard pycryptodome fully for the time being, unsure how to make it play nicely
+        if resource.name.startswith("Crypto"):
+            continue
+
+        exe.add_python_resource(resource)
+
+    # Add the _pluginlist.py "overlay"
+    # This is created by the CI, if you want to build manually, be sure to generate it:
+    # mkdir -p build/lib/dissect/target/plugins/ && target-build-pluginlist > build/lib/dissect/target/plugins/_pluginlist.py
+    exe.add_python_resources(exe.read_package_root("build/lib", ["dissect"]))
+
+    # If you want to add your own configuration customizations, you can put them in here
+    # 'arguments' allows you to override specific arguments by default, e.g. ['--compress']
+    # 'public_key' allows you to include a PEM encoded RSA public key for output encryption
+    # NOTE: pycryptodome is not currently packaged in this PyOxidizer configuration, so output encryption is unavailable
+    # 'upload' allows you to configure upload credentials
+    # Example AWS S3 configuration: {'mode': 'cloud', 'endpoint': 's3.amazonaws.com', 'access_id': '', 'access_key': '', 'bucket': ''}
+    exe.add_python_resource(
+        exe.make_python_module_source(
+            "acquire.config",
+            "CONFIG = {'arguments': [], 'public_key': '', 'upload': {}}",
+            False
+        )
+    )
+
+    return exe
+
+
+def make_embedded_resources(exe):
+    return exe.to_embedded_resources()
+
+
+def make_install(exe):
+    files = FileManifest()
+    files.add_python_resource(".", exe)
+
+    return files
+
+
+register_target("exe", make_exe)
+register_target("resources", make_embedded_resources, depends=["exe"], default_build_script=True)
+register_target("install", make_install, depends=["exe"], default=True)
+
+resolve_targets()

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -20,7 +20,7 @@ def make_exe():
 
     # The default dependency list of acquire doesn't include enough, and full includes some that are hard to package
     pip_args = [
-        "acquire",
+        "acquire==" + VARS["version"],
         "dissect.cstruct",
         "dissect.eventlog",
         "dissect.evidence",


### PR DESCRIPTION
This PR adds CI for building PyOxidizer binaries for Windows, macOS, Linux (GNU) and Linux (musl). 

The Linux musl build currently depends on a forked PyOxidizer (https://github.com/fox-it/PyOxidizer/tree/esxi-compatibility) because of https://github.com/indygreg/PyOxidizer/pull/725. The fork also includes a workaround for ESXi.

The Linux GNU build is built in a `manylinux2014` container to ensure an old libc version for compatibility.

The macOS build combines a x86_64 and aarch64 binary into a single universal2 binary for compatibility on both Intel and Apple Silicon Macs.

A separate list of dependencies is currently maintained in `pyoxidizer.bzl` because there are no appropriate dependency bundles available in acquire right now. `minio` is included for uploading to cloud storage, but unfortunately `pycryptodome` is not yet included. It _should_ be possible to include it but I couldn't get it working across all OS variants right now, so that could be a future improvement. The way to go here is likely a filesystem fallback on an accompanied `lib` directory, but for some reason this broke the embedded `msgpack`. PyOxidizer should also be able to [recompile an extension into itself](https://gregoryszorc.com/docs/pyoxidizer/main/pyoxidizer_packaging_extension_modules.html#building-with-a-custom-distutils) but I did not look into this yet.

The `pyoxidizer.bzl` file also includes comments explaining how to build manually, as well as how you could modify the embedded configuration.

Ideally we add these binaries as files into the releases, but I wasn't sure what the desired CI trigger would be for that, so I've put it on tags for now. For this reason, the PyOxidizer also currently downloads the latest stable `acquire` from PyPI instead of copying from the local source repository.