### PR TITLE
Add default SearchIndex database file location

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -937,7 +937,7 @@ class Misc(Module):
         ("glob", "sysvol/ProgramData/USOShared/Logs/System/*.etl"),
         ("glob", "sysvol/Windows/Logs/WindowsUpdate/WindowsUpdate*.etl"),
         ("glob", "sysvol/Windows/Logs/CBS/CBS*.log"),
-        ("glob", "sysvol/ProgramData/Microsoft/Search/Data/Applications/Windows/Windows*"),
+        ("dir", "sysvol/ProgramData/Microsoft/Search/Data/Applications/Windows"),
     ]
 
 

--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -937,6 +937,7 @@ class Misc(Module):
         ("glob", "sysvol/ProgramData/USOShared/Logs/System/*.etl"),
         ("glob", "sysvol/Windows/Logs/WindowsUpdate/WindowsUpdate*.etl"),
         ("glob", "sysvol/Windows/Logs/CBS/CBS*.log"),
+        ("glob", "sysvol/ProgramData/Microsoft/Search/Data/Applications/Windows/Windows*"),
     ]
 
 


### PR DESCRIPTION
I've been working on the dissect.target implementation for the SearchIndex forensic artifact. (https://www.aon.com/cyber-solutions/aon_cyber_labs/windows-search-index-the-forensic-artifact-youve-been-searching-for/)

Adding the default directory for the important databases to acquire to collect the relevant files.