### PR TITLE
Map all Windows sysvol paths to their drive letter

### DIFF
--- a/acquire/collector.py
+++ b/acquire/collector.py
@@ -207,13 +207,6 @@ class Collector:
         self.bound_module_name = None
         self.filter = lambda _: False
 
-        self._sysvol_drive = None
-        if target.os == "windows":
-            self._sysvol_drive = next(
-                (mnt for mnt, fs in target.fs.mounts.items() if fs is target.fs.mounts["sysvol"] and mnt != "sysvol"),
-                None,
-            )
-
         self.output.init(self.target)
 
     def __enter__(self) -> Collector:
@@ -252,8 +245,8 @@ class Collector:
         base = base or self.base
         outpath = str(path)
 
-        if self._sysvol_drive:
-            outpath = normalize_sysvol(outpath, self._sysvol_drive)
+        if sysvol_drive := self.target.props.get("sysvol_drive"):
+            outpath = normalize_sysvol(outpath, sysvol_drive)
 
         if base:
             # Make sure that `outpath` is not an abolute path, since
@@ -440,7 +433,7 @@ class Collector:
         if not isinstance(path, fsutil.TargetPath):
             path = self.target.fs.path(path)
 
-        if self.skip_list and normalize_path(self.target, path, sysvol=self._sysvol_drive) in self.skip_list:
+        if self.skip_list and normalize_path(self.target, path) in self.skip_list:
             self.report.add_path_failed(module_name, path)
             log.error("- Skipping collection of %s, path is on the skip list", path)
             return

--- a/acquire/collector.py
+++ b/acquire/collector.py
@@ -30,7 +30,12 @@ from dissect.target.exceptions import (
 )
 from dissect.target.helpers import fsutil
 
-from acquire.utils import StrEnum, get_formatted_exception, normalize_path
+from acquire.utils import (
+    StrEnum,
+    get_formatted_exception,
+    normalize_path,
+    normalize_sysvol,
+)
 
 if TYPE_CHECKING:
     from acquire.outputs.base import Output
@@ -247,8 +252,8 @@ class Collector:
         base = base or self.base
         outpath = str(path)
 
-        if self._sysvol_drive and outpath.startswith(("sysvol/", "/sysvol/")):
-            outpath = outpath.replace("sysvol", self._sysvol_drive, 1)
+        if self._sysvol_drive:
+            outpath = normalize_sysvol(outpath, self._sysvol_drive)
 
         if base:
             # Make sure that `outpath` is not an abolute path, since
@@ -435,7 +440,7 @@ class Collector:
         if not isinstance(path, fsutil.TargetPath):
             path = self.target.fs.path(path)
 
-        if self.skip_list and normalize_path(self.target, path) in self.skip_list:
+        if self.skip_list and normalize_path(self.target, path, sysvol=self._sysvol_drive) in self.skip_list:
             self.report.add_path_failed(module_name, path)
             log.error("- Skipping collection of %s, path is on the skip list", path)
             return

--- a/acquire/collector.py
+++ b/acquire/collector.py
@@ -202,6 +202,13 @@ class Collector:
         self.bound_module_name = None
         self.filter = lambda _: False
 
+        self._sysvol_drive = None
+        if target.os == "windows":
+            self._sysvol_drive = next(
+                (mnt for mnt, fs in target.fs.mounts.items() if fs is target.fs.mounts["sysvol"] and mnt != "sysvol"),
+                None,
+            )
+
         self.output.init(self.target)
 
     def __enter__(self) -> Collector:
@@ -239,6 +246,9 @@ class Collector:
     def _output_path(self, path: Path, base: Optional[str] = None) -> str:
         base = base or self.base
         outpath = str(path)
+
+        if self._sysvol_drive and outpath.startswith(("sysvol/", "/sysvol/")):
+            outpath = outpath.replace("sysvol", self._sysvol_drive, 1)
 
         if base:
             # Make sure that `outpath` is not an abolute path, since

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -368,10 +368,13 @@ def persist_execution_report(path: Path, report_data: dict) -> Path:
         f.write(json.dumps(report_data, sort_keys=True, indent=4))
 
 
-SYSVOL_SUBST = re.compile(r"^(/\?\?/)?[cC]:")
+DEVICE_SUBST = re.compile(r"^(/\?\?/)")
+SYSVOL_SUBST = re.compile(r"^/?sysvol(?=/)")
 
 
-def normalize_path(target: Target, path: Path, resolve: bool = False, lower_case: bool = True) -> str:
+def normalize_path(
+    target: Target, path: Path, *, sysvol: Optional[str] = None, resolve: bool = False, lower_case: bool = True
+) -> str:
     if resolve:
         path = path.resolve()
 
@@ -381,7 +384,12 @@ def normalize_path(target: Target, path: Path, resolve: bool = False, lower_case
         path = path.lower()
 
     if target.os == "windows":
-        # As dissect.target always maps c: onto sysvol, we can do this substitution here.
-        path = SYSVOL_SUBST.sub("sysvol", path)
+        path = DEVICE_SUBST.sub("", path)
+        if sysvol:
+            path = normalize_sysvol(path, sysvol)
 
     return path
+
+
+def normalize_sysvol(path: str, sysvol: str) -> str:
+    return SYSVOL_SUBST.sub(sysvol, path)

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -369,24 +369,22 @@ def persist_execution_report(path: Path, report_data: dict) -> Path:
 
 
 DEVICE_SUBST = re.compile(r"^(/\?\?/)")
-SYSVOL_SUBST = re.compile(r"^/?sysvol(?=/)")
+SYSVOL_SUBST = re.compile(r"^/?sysvol(?=/)", flags=re.IGNORECASE)
 
 
-def normalize_path(
-    target: Target, path: Path, *, sysvol: Optional[str] = None, resolve: bool = False, lower_case: bool = True
-) -> str:
+def normalize_path(target: Target, path: Path, *, resolve: bool = False, lower_case: bool = True) -> str:
     if resolve:
         path = path.resolve()
 
     path = path.as_posix()
 
-    if not target.fs.case_sensitive and lower_case:
-        path = path.lower()
-
     if target.os == "windows":
         path = DEVICE_SUBST.sub("", path)
-        if sysvol:
-            path = normalize_sysvol(path, sysvol)
+        if sysvol_drive := target.props.get("sysvol_drive"):
+            path = normalize_sysvol(path, sysvol_drive)
+
+    if not target.fs.case_sensitive and lower_case:
+        path = path.lower()
 
     return path
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -383,10 +383,10 @@ def test_collector_sysvol_map() -> None:
     mock_target = Mock()
     mock_target.os = "windows"
     mock_target.fs.mounts = {"sysvol": vfs, "y:": vfs}
+    mock_target.props = {"sysvol_drive": "y:"}
 
     mock_output = Mock(spec=Output)
 
     collector = Collector(mock_target, mock_output)
 
-    assert collector._sysvol_drive == "y:"
     assert collector._output_path("sysvol/some/path") == "fs/y:/some/path"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import argparse
 import pathlib
 import platform
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ from acquire.utils import (
     check_and_set_log_args,
     create_argument_parser,
     normalize_path,
+    normalize_sysvol,
 )
 
 
@@ -296,10 +298,11 @@ def test_check_and_set_acquire_args_cagent():
 
 
 @pytest.mark.parametrize(
-    "path, resolve, lower_case, case_sensitive, os, result",
+    "path, sysvol, resolve, lower_case, case_sensitive, os, result",
     [
         (
             pathlib.Path("/foo/bar"),
+            None,
             False,
             True,
             True,
@@ -308,6 +311,7 @@ def test_check_and_set_acquire_args_cagent():
         ),
         (
             pathlib.Path("/foo/BAR"),
+            None,
             False,
             True,
             False,
@@ -316,6 +320,7 @@ def test_check_and_set_acquire_args_cagent():
         ),
         (
             pathlib.Path("/foo/BAR"),
+            None,
             False,
             True,
             True,
@@ -324,6 +329,7 @@ def test_check_and_set_acquire_args_cagent():
         ),
         (
             pathlib.Path("/foo/../bar"),
+            None,
             False,
             True,
             True,
@@ -332,6 +338,7 @@ def test_check_and_set_acquire_args_cagent():
         ),
         (
             pathlib.Path("/foo/../foo/bar"),
+            None,
             True,
             True,
             True,
@@ -340,38 +347,43 @@ def test_check_and_set_acquire_args_cagent():
         ),
         (
             pathlib.PureWindowsPath("c:\\foo\\bar"),
+            "c:",
             False,
             True,
             False,
             "windows",
-            "sysvol/foo/bar",
+            "c:/foo/bar",
         ),
         (
             pathlib.PureWindowsPath("C:\\foo\\bar"),
+            "c:",
             False,
             True,
             False,
             "windows",
-            "sysvol/foo/bar",
+            "c:/foo/bar",
         ),
         (
             pathlib.PureWindowsPath("\\??\\C:\\foo\\bar"),
+            "c:",
             False,
             True,
             False,
             "windows",
-            "sysvol/foo/bar",
+            "c:/foo/bar",
         ),
         (
             pathlib.PureWindowsPath("\\??\\c:\\foo\\bar"),
+            "c:",
             False,
             True,
             False,
             "windows",
-            "sysvol/foo/bar",
+            "c:/foo/bar",
         ),
         (
             pathlib.PureWindowsPath("D:\\foo\\bar"),
+            "c:",
             False,
             True,
             False,
@@ -380,17 +392,28 @@ def test_check_and_set_acquire_args_cagent():
         ),
         (
             pathlib.PureWindowsPath("D:\\Foo\\BAR"),
+            "c:",
             False,
             False,
             False,
             "windows",
             "D:/Foo/BAR",
         ),
+        (
+            pathlib.PureWindowsPath("sysvol\\foo\\bar"),
+            "c:",
+            False,
+            False,
+            False,
+            "windows",
+            "c:/foo/bar",
+        ),
     ],
 )
 def test_utils_normalize_path(
     mock_target: Target,
     path: pathlib.Path,
+    sysvol: Optional[str],
     resolve: bool,
     lower_case: bool,
     case_sensitive: bool,
@@ -398,7 +421,7 @@ def test_utils_normalize_path(
     result: str,
 ) -> None:
     with patch.object(mock_target, "os", new=os), patch.object(mock_target.fs, "_case_sensitive", new=case_sensitive):
-        resolved_path = normalize_path(mock_target, path, resolve=resolve, lower_case=lower_case)
+        resolved_path = normalize_path(mock_target, path, sysvol=sysvol, resolve=resolve, lower_case=lower_case)
 
         if platform.system() == "Windows":
             # A resolved path on windows adds a C:\ prefix. So we check if it ends with our expected
@@ -406,3 +429,14 @@ def test_utils_normalize_path(
             assert resolved_path.endswith(result)
         else:
             assert resolved_path == result
+
+
+@pytest.mark.parametrize(
+    "path, sysvol, result",
+    [
+        ("sysvol/foo/bar", "c:", "c:/foo/bar"),
+        ("/sysvol/foo/bar", "c:", "c:/foo/bar"),
+    ],
+)
+def test_normalize_sysvol(path: str, sysvol: str, result: str) -> None:
+    assert normalize_sysvol(path, sysvol) == result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -420,8 +420,10 @@ def test_utils_normalize_path(
     os: str,
     result: str,
 ) -> None:
-    with patch.object(mock_target, "os", new=os), patch.object(mock_target.fs, "_case_sensitive", new=case_sensitive):
-        resolved_path = normalize_path(mock_target, path, sysvol=sysvol, resolve=resolve, lower_case=lower_case)
+    with patch.object(mock_target, "os", new=os), patch.object(
+        mock_target.fs, "_case_sensitive", new=case_sensitive
+    ), patch.dict(mock_target.props, {"sysvol_drive": sysvol}):
+        resolved_path = normalize_path(mock_target, path, resolve=resolve, lower_case=lower_case)
 
         if platform.system() == "Windows":
             # A resolved path on windows adds a C:\ prefix. So we check if it ends with our expected


### PR DESCRIPTION
Required for https://github.com/fox-it/dissect.target/pull/497.

Allows `dissect.target` to support acquire outputs for systems that have a non-default sysvol drive letter.