### PR TITLE
Add AttributeError to except ImportError statements

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -59,13 +59,13 @@ from acquire.utils import (
 
 try:
     from acquire.version import version
-except ImportError:
+except (AttributeError, ImportError):
     version = "0.0.dev"
 
 try:
     # Injected by pystandalone builder
     from acquire.config import CONFIG
-except ImportError:
+except (AttributeError, ImportError):
     CONFIG = defaultdict(lambda: None)
 
 

--- a/acquire/crypt.py
+++ b/acquire/crypt.py
@@ -10,7 +10,7 @@ try:
     from Crypto.Random import get_random_bytes
 
     HAS_PYCRYPTODOME = True
-except ImportError:
+except (AttributeError, ImportError):
     HAS_PYCRYPTODOME = False
 
 

--- a/acquire/tools/decrypter.py
+++ b/acquire/tools/decrypter.py
@@ -44,7 +44,7 @@ try:
         TimeRemainingColumn(),
         transient=True,
     )
-except ImportError:
+except (AttributeError, ImportError):
     progress = None
 
 from acquire.crypt import (

--- a/acquire/uploaders/minio.py
+++ b/acquire/uploaders/minio.py
@@ -37,7 +37,7 @@ class MinIO(UploaderPlugin):
         try:
             import urllib3
             from minio import Minio
-        except ImportError:
+        except (AttributeError, ImportError):
             raise RuntimeError("Minio upload module is not available")
 
         http_client = urllib3.proxy_from_url(proxies["http"]) if proxies else None

--- a/acquire/volatilestream.py
+++ b/acquire/volatilestream.py
@@ -10,7 +10,7 @@ try:
     from fcntl import F_SETFL, fcntl
 
     HAS_FCNTL = True
-except ImportError:
+except (AttributeError, ImportError):
     HAS_FCNTL = False
 
 


### PR DESCRIPTION
In some cases windows throws an AttributeError instead of an ImportError during an import