### PR TITLE
Add collection of notepad tab directories

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -927,9 +927,10 @@ class ThumbnailCache(Module):
 @register_module("--texteditor-tabs")
 class TexteditorTabs(Module):
     DESC = "Texteditor (un)saved tab contents"
-    # Only Windows 11 notepad tabs for now, but locations for other text editors may be added later.
+    # Only Windows 11 notepad & Notepad++ tabs for now, but locations for other text editors may be added later.
     SPEC = [
         ("dir", "AppData/Local/Packages/Microsoft.WindowsNotepad_8wekyb3d8bbwe/LocalState/TabState/", from_user_home),
+        ("dir", "AppData/Roaming/Notepad++/backup/", from_user_home),
     ]
 
 

--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -924,6 +924,15 @@ class ThumbnailCache(Module):
     ]
 
 
+@register_module("--texteditor-tabs")
+class TexteditorTabs(Module):
+    DESC = "Texteditor (un)saved tab contents"
+    # Only Windows 11 notepad tabs for now, but locations for other text editors may be added later.
+    SPEC = [
+        ("dir", "AppData/Local/Packages/Microsoft.WindowsNotepad_8wekyb3d8bbwe/LocalState/TabState/", from_user_home),
+    ]
+
+
 @register_module("--misc")
 class Misc(Module):
     DESC = "miscellaneous Windows artefacts"
@@ -1969,6 +1978,7 @@ class WindowsProfile:
         WindowsNotifications,
         SSH,
         IIS,
+        TexteditorTabs,
     ]
 
 

--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -924,9 +924,9 @@ class ThumbnailCache(Module):
     ]
 
 
-@register_module("--texteditor-tabs")
-class TexteditorTabs(Module):
-    DESC = "Texteditor (un)saved tab contents"
+@register_module("--text-editor")
+class TextEditor(Module):
+    DESC = "text editor (un)saved tab contents"
     # Only Windows 11 notepad & Notepad++ tabs for now, but locations for other text editors may be added later.
     SPEC = [
         ("dir", "AppData/Local/Packages/Microsoft.WindowsNotepad_8wekyb3d8bbwe/LocalState/TabState/", from_user_home),
@@ -1979,7 +1979,7 @@ class WindowsProfile:
         WindowsNotifications,
         SSH,
         IIS,
-        TexteditorTabs,
+        TextEditor,
     ]
 
 


### PR DESCRIPTION
Acquire part for https://github.com/fox-it/dissect.target/pull/540. For now, only collect the Windows 11 notepad tab directory, but this may of course be extended. Also added it to the `full` profile.