### PR TITLE
Fix compression in zip outputs when compress option is supplied

### DIFF
--- a/acquire/outputs/zip.py
+++ b/acquire/outputs/zip.py
@@ -38,7 +38,7 @@ class ZipOutput(Output):
         self.path = path.with_suffix(path.suffix + ext)
 
         if compress:
-            self.compression = zipfile.ZIP_LZMA
+            self.compression = zipfile.ZIP_DEFLATED
         else:
             self.compression = zipfile.ZIP_STORED
 
@@ -75,6 +75,7 @@ class ZipOutput(Output):
         info = zipfile.ZipInfo()
         info.filename = output_path
         info.file_size = size or 0
+        info.compress_type = self.compression
 
         if entry:
             if entry.is_symlink():


### PR DESCRIPTION
The zip outputs of acquire ignored the compression type given, due to the use of zipfile.ZipInfo without supplying a compression type to these objects. This PR fixes that.

I also changed the compression type to deflate, as this is better supported throughout other forensic tools (read: tools we use ourselves to process acquire collects)

