### PR TITLE
Fix inconsistent error messages involving `output-file`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,9 @@ __pycache__/
 acquire/version.py
 tests/docs/api
 tests/docs/build
-.tox/log
+.tox/
 
-# Ignore artefacts created by an acquire run
+# Ignore artefacts created by an acquire run in the package directory
 *.tar
 *.log
 *.report.json 

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,3 @@ acquire/version.py
 tests/docs/api
 tests/docs/build
 .tox/
-
-# Ignore artefacts created by an acquire run in the package directory
-*.tar
-*.log
-*.report.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,9 @@ __pycache__/
 acquire/version.py
 tests/docs/api
 tests/docs/build
-.tox/
+.tox/log
+
+# Ignore artefacts created by an acquire run
+*.tar
+*.log
+*.report.json 

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ tests/docs/build
 # Ignore artefacts created by an acquire run in the package directory
 *.tar
 *.log
-*.report.json 
+*.report.json

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -312,9 +312,9 @@ def check_and_set_acquire_args(
     if not args.upload:
         # check output related configuration
         if (args.children or len(args.targets) > 1) and args.output_file:
-            raise ValueError("--children can not be used with --output_file. Use --output instead")
+            raise ValueError("--children can not be used with --output-file. Use --output instead")
         elif args.output_file and (not args.output_file.parent.is_dir() or args.output_file.is_dir()):
-            raise ValueError("--output_file must be a path to a file in an existing directory")
+            raise ValueError("--output-file must be a path to a file in an existing directory")
         elif args.output and not args.output.is_dir():
             raise ValueError(f"Output directory doesn't exist or is a file: {args.output}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -229,21 +229,21 @@ def test_check_and_set_acquire_args_output(children: bool, arg_name: str, output
             True,
             "output_file",
             get_mock_path(is_dir=False),
-            "--children can not be used with --output_file. Use --output instead",
+            "--children can not be used with --output-file. Use --output instead",
         ),
         # Output_file is a directory
         (
             False,
             "output_file",
             get_mock_path(),
-            "--output_file must be a path to a file in an existing directory",
+            "--output-file must be a path to a file in an existing directory",
         ),
         # Output_file has a non-existing parent directory
         (
             False,
             "output_file",
             get_mock_path(is_dir=False, parent_is_dir=False),
-            "--output_file must be a path to a file in an existing directory",
+            "--output-file must be a path to a file in an existing directory",
         ),
         # Output is a non-existing directory
         (


### PR DESCRIPTION
_Note: There are failing CI checks unrelated to this pr.  After CI is fixed, this PR can be re-reviewed._  

Make error messages concerning  `output-file` consistent with the name of the flag.

extra: 
- git ignore acquire artifacts when running the package from the root. 
- fully git ignore the .tox directory

closes #169 
