### PR TITLE
Add collection of individual user search indexes on Windows

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -945,7 +945,10 @@ class Misc(Module):
         ("glob", "sysvol/ProgramData/USOShared/Logs/System/*.etl"),
         ("glob", "sysvol/Windows/Logs/WindowsUpdate/WindowsUpdate*.etl"),
         ("glob", "sysvol/Windows/Logs/CBS/CBS*.log"),
+        # Windows Search DB
         ("dir", "sysvol/ProgramData/Microsoft/Search/Data/Applications/Windows"),
+        # Windows Search DB - Windows Search Database Roaming
+        ("glob", "AppData/Roaming/Microsoft/Search/Data/Applications/S-1-*/*", from_user_home),
         ("dir", "sysvol/Windows/SoftwareDistribution/DataStore"),
     ]
 


### PR DESCRIPTION
Server Editions of Windows have the capability to support per user search databases (Windows Search database roaming). The artefacts appear to be in the same format as the ones stored in the standard folder but split out per user. Verified on Server 2022 and Server 2025 using the HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Search: "EnablePerUserCatalog"=dword:00000001 registry key.
