### PR TITLE
Fix regression in OSError handling logic

### DIFF
--- a/acquire/collector.py
+++ b/acquire/collector.py
@@ -518,6 +518,9 @@ class Collector:
                     self.report.add_symlink_collected(module_name, branch_path)
                     log.info("- Collecting symlink branch suceeded %s", branch_path)
 
+        except (FileNotFoundError, NotADirectoryError, NotASymlinkError, SymlinkRecursionError, ValueError):
+            self.report.add_path_missing(module_name, error_path)
+            log.error("- Path %s is not found (while collecting %s)", error_path, path)
         except OSError as error:
             if error.errno == errno.ENOENT:
                 self.report.add_path_missing(module_name, error_path)
@@ -528,9 +531,6 @@ class Collector:
             else:
                 self.report.add_path_failed(module_name, error_path)
                 log.error("- OSError while collecting path %s (while collecting %s)", error_path, path)
-        except (FileNotFoundError, NotADirectoryError, NotASymlinkError, SymlinkRecursionError, ValueError):
-            self.report.add_path_missing(module_name, error_path)
-            log.error("- Path %s is not found (while collecting %s)", error_path, path)
         except Exception:
             self.report.add_path_failed(module_name, error_path)
             log.error("- Failed to collect path %s (while collecting %s)", error_path, path, exc_info=True)


### PR DESCRIPTION
dissect.target's NotADirectoryError and FileNotFoundError are now proper subclasses of the std.NotADirectoryError and std.FileNotFoundError and by this a subclass of OSError, so they should be treated as such.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
