### PR TITLE
Added brave history path when installed with snap

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -1212,6 +1212,8 @@ class History(Module):
         ("glob", ".mozilla/firefox/*/*.sqlite*", from_user_home),
         # Firefox - RHEL/Ubuntu - snap
         ("glob", "snap/firefox/common/.mozilla/firefox/*/*.sqlite*", from_user_home),
+        # Brave - Ubuntu - snap
+        ("glob", "snap/brave/[0-9]*/.config/BraveSoftware/**"),
         # Safari - macOS
         ("file", "Library/Safari/Bookmarks.plist", from_user_home),
         ("file", "Library/Safari/Downloads.plist", from_user_home),

--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -1213,7 +1213,7 @@ class History(Module):
         # Firefox - RHEL/Ubuntu - snap
         ("glob", "snap/firefox/common/.mozilla/firefox/*/*.sqlite*", from_user_home),
         # Brave - Ubuntu - snap
-        ("glob", "snap/brave/[0-9]*/.config/BraveSoftware/**"),
+        ("glob", "snap/brave/[0-9]*/.config/BraveSoftware/**", from_user_home),
         # Safari - macOS
         ("file", "Library/Safari/Bookmarks.plist", from_user_home),
         ("file", "Library/Safari/Downloads.plist", from_user_home),


### PR DESCRIPTION
I had already added a snap installation path to parse Brave browser history in another [PR for dissect.target](https://github.com/fox-it/dissect.target/pull/1031). This PR makes sure that acquire will collect it as well.
