### PR TITLE
Add flag to enable nfs

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -2240,6 +2240,9 @@ def main() -> None:
                 if args.fallback:
                     target_query.update({"fallback-to-directory-fs": 1})
 
+                if args.enable_nfs:
+                    target_query.update({"enable-nfs": 1})
+
                 target_query = urllib.parse.urlencode(target_query)
                 target_path = f"{target_path}?{target_query}"
             target_paths.append(target_path)

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -153,6 +153,14 @@ def create_argument_parser(profiles: dict, volatile: dict, modules: dict) -> arg
             "Only supported with target 'local'"
         ),
     )
+    parser.add_argument(
+        "--enable-nfs",
+        action=argparse.BooleanOptionalAction,
+        help=(
+            "mount nfs shares by connecting to the nfs server of the share."
+            "Only supported with target 'local'"
+        ),
+    )
 
     parser.add_argument(
         "-u",


### PR DESCRIPTION
As discussed internally, we disabled automatic nfs mounting.
This PR adds a flag to enable mounting of any found nfs shares 