### PR TITLE
Add NTFS and RemoteAccess paths

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -1347,11 +1347,11 @@ class RemoteAccess(Module):
     SPEC = (
         # teamviewer - Windows
         ("glob", "sysvol/Program Files/TeamViewer/*.log"),
-        ("glob", "sysvol/Program Files/TeamViewer/Connections_incoming.txt"),
+        ("path", "sysvol/Program Files/TeamViewer/Connections_incoming.txt"),
         ("glob", "sysvol/Program Files (x86)/TeamViewer/*.log"),
-        ("glob", "sysvol/Program Files (x86)/TeamViewer/Connections_incoming.txt"),
+        ("path", "sysvol/Program Files (x86)/TeamViewer/Connections_incoming.txt"),
         ("glob", "AppData/Roaming/TeamViewer/*.log", from_user_home),
-        ("glob", "AppData/Roaming/TeamViewer/Connections.txt", from_user_home),
+        ("path", "AppData/Roaming/TeamViewer/Connections.txt", from_user_home),
         # teamviewer - Mac + Linux
         ("glob", "/var/log/teamviewer*/*.log"),
         ("glob", "Library/Logs/TeamViewer/*.log", from_user_home),


### PR DESCRIPTION
closes #258
closes #155
closes #180

Initially just wanted to add RustDesk paths, but noticed some easy to fix issues so added those as well. 

Looking at the [RustDesk Github Page](https://github.com/rustdesk/rustdesk/wiki/FAQ), I noticed that some files would not get collected with the current config. This PR should fix that.