### PR TITLE
Prevent .tar file corruption by patching short reads

### DIFF
--- a/acquire/outputs/tar.py
+++ b/acquire/outputs/tar.py
@@ -129,7 +129,6 @@ class TarOutput(Output):
                 # Prevents "long reads" because it reads at max bufsize bytes at a time
                 buf = fh.read(bufsize)
                 if len(buf) < bufsize:
-                    # raise exception("unexpected end of data")
                     # PATCH; instead of raising an exception, pad the data to the desired length
                     buf += tarfile.NUL * (bufsize - len(buf))
                 self.tar.fileobj.write(buf)
@@ -138,7 +137,6 @@ class TarOutput(Output):
                 # Prevents "long reads" because it reads at max bufsize bytes at a time
                 buf = fh.read(remainder)
                 if len(buf) < remainder:
-                    # raise exception("unexpected end of data")
                     # PATCH; instead of raising an exception, pad the data to the desired length
                     buf += tarfile.NUL * (remainder - len(buf))
                 self.tar.fileobj.write(buf)

--- a/acquire/outputs/tar.py
+++ b/acquire/outputs/tar.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import io
-import shutil
 import tarfile
 from typing import TYPE_CHECKING, BinaryIO
 
@@ -107,47 +106,49 @@ class TarOutput(Output):
         self.tar._check("awx")
 
         if fh is None and info.isreg() and info.size != 0:
-            raise ValueError("fileobj not provided for non zero-size regular file")
+            return
 
-        info = copy.copy(info)
+        tarinfo = copy.copy(info)
+        saved_offset = self.tar.offset
+        saved_filepos = self.tar.fileobj.tell()
 
-        buf = info.tobuf(self.tar.format, self.tar.encoding, self.tar.errors)
-        self.tar.fileobj.write(buf)
-        self.tar.offset += len(buf)
-        bufsize = self.tar.copybufsize
-        if fh is not None:
-            bufsize = bufsize or 16 * 1024
+        try:
+            buf = tarinfo.tobuf(self.tar.format, self.tar.encoding, self.tar.errors)
+            self.tar.fileobj.write(buf)
+            self.tar.offset += len(buf)
+            bufsize = self.tar.copybufsize or 16 * 1024
 
-            if info.size == 0:
-                return
-            if info.size is None:
-                shutil.copyfileobj(fh, self.tar.fileobj, bufsize)
-                return
+            if fh is not None:
+                if tarinfo.size is None or tarinfo.size == 0:
+                    return
 
-            blocks, remainder = divmod(info.size, bufsize)
-            for _ in range(blocks):
-                # Prevents "long reads" because it reads at max bufsize bytes at a time
-                buf = fh.read(bufsize)
-                if len(buf) < bufsize:
-                    # PATCH; instead of raising an exception, pad the data to the desired length
-                    buf += tarfile.NUL * (bufsize - len(buf))
-                self.tar.fileobj.write(buf)
+                blocks, remainder = divmod(tarinfo.size, bufsize)
+                for _ in range(blocks):
+                    buf = fh.read(size)
+                    if len(buf) < size:
+                        # PATCH; instead of raising an exception, pad the data to the desired length
+                        buf += tarfile.NUL * (size - len(buf))
+                    self.tar.fileobj.write(buf)
 
-            if remainder != 0:
-                # Prevents "long reads" because it reads at max bufsize bytes at a time
-                buf = fh.read(remainder)
-                if len(buf) < remainder:
-                    # PATCH; instead of raising an exception, pad the data to the desired length
-                    buf += tarfile.NUL * (remainder - len(buf))
-                self.tar.fileobj.write(buf)
+                if remainder > 0:
+                    buf = fh.read(remainder)
+                    if len(buf) < remainder:
+                        # PATCH; instead of raising an exception, pad the data to the desired length
+                        buf += tarfile.NUL * (remainder - len(buf))
+                    self.tar.fileobj.write(buf)
 
-            blocks, remainder = divmod(info.size, tarfile.BLOCKSIZE)
-            if remainder > 0:
-                self.tar.fileobj.write(tarfile.NUL * (tarfile.BLOCKSIZE - remainder))
-                blocks += 1
-            self.tar.offset += blocks * tarfile.BLOCKSIZE
+                blocks, remainder = divmod(tarinfo.size, tarfile.BLOCKSIZE)
+                if remainder > 0:
+                    self.tar.fileobj.write(tarfile.NUL * (tarfile.BLOCKSIZE - remainder))
+                    blocks += 1
+                self.tar.offset += blocks * tarfile.BLOCKSIZE
 
-        self.tar.members.append(info)
+            self.tar.members.append(tarinfo)
+        except Exception:
+            self.tar.fileobj.seek(saved_filepos)
+            self.tar.fileobj.truncate()
+            self.tar.offset = saved_offset
+            raise
 
     def close(self) -> None:
         """Closes the tar file."""

--- a/acquire/outputs/tar.py
+++ b/acquire/outputs/tar.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import copy
 import io
+import shutil
 import tarfile
+from logging import getLogger
 from typing import TYPE_CHECKING, BinaryIO
 
 from acquire.crypt import EncryptedStream
@@ -14,6 +16,7 @@ if TYPE_CHECKING:
     from dissect.target.filesystem import FilesystemEntry
 
 TAR_COMPRESSION_METHODS = {"gzip": "gz", "bzip2": "bz2", "xz": "xz"}
+log = getLogger(__name__)
 
 
 class TarOutput(Output):
@@ -109,6 +112,7 @@ class TarOutput(Output):
             return
 
         tarinfo = copy.copy(info)
+
         saved_offset = self.tar.offset
         saved_filepos = self.tar.fileobj.tell()
 
@@ -116,18 +120,22 @@ class TarOutput(Output):
             buf = tarinfo.tobuf(self.tar.format, self.tar.encoding, self.tar.errors)
             self.tar.fileobj.write(buf)
             self.tar.offset += len(buf)
-            bufsize = self.tar.copybufsize or 16 * 1024
 
             if fh is not None:
-                if tarinfo.size is None or tarinfo.size == 0:
+                # Start of tarfile.copyfileobj
+                bufsize = self.tar.copybufsize or 16 * 1024
+                if tarinfo.size == 0:
+                    return
+                if tarinfo.size is None:
+                    shutil.copyfileobj(fh, self.tar.fileobj, bufsize)
                     return
 
                 blocks, remainder = divmod(tarinfo.size, bufsize)
                 for _ in range(blocks):
-                    buf = fh.read(size)
-                    if len(buf) < size:
+                    buf = fh.read(bufsize)
+                    if len(buf) < bufsize:
                         # PATCH; instead of raising an exception, pad the data to the desired length
-                        buf += tarfile.NUL * (size - len(buf))
+                        buf += tarfile.NUL * (bufsize - len(buf))
                     self.tar.fileobj.write(buf)
 
                 if remainder > 0:
@@ -136,6 +144,7 @@ class TarOutput(Output):
                         # PATCH; instead of raising an exception, pad the data to the desired length
                         buf += tarfile.NUL * (remainder - len(buf))
                     self.tar.fileobj.write(buf)
+                # End of tarfile.copyfileobj
 
                 blocks, remainder = divmod(tarinfo.size, tarfile.BLOCKSIZE)
                 if remainder > 0:
@@ -145,6 +154,11 @@ class TarOutput(Output):
 
             self.tar.members.append(tarinfo)
         except Exception:
+            log.warning(
+                "An error occurred while writing to the tar file. "
+                "Truncating to the last known good state (offset: %d).",
+                saved_filepos,
+            )
             self.tar.fileobj.seek(saved_filepos)
             self.tar.fileobj.truncate()
             self.tar.offset = saved_offset

--- a/acquire/outputs/tar.py
+++ b/acquire/outputs/tar.py
@@ -28,9 +28,11 @@ def copyfileobj(
     name: str = "",
 ) -> None:
     """Copy length bytes from fileobj src to fileobj dst.
-       If length is None, copy the entire content.
-       Inlined from the Python 3.13 function `tarfile.copyfileobj`, 
-       patched to pad a short read with NUL bytes instead of raising.
+
+    If length is None, copy the entire content.
+
+    Inlined from the Python 3.13 function ``tarfile.copyfileobj``, patched to pad a short read with
+    NUL bytes instead of raising.
     """
     bufsize = bufsize or 16 * 1024
     if length == 0:

--- a/acquire/outputs/tar.py
+++ b/acquire/outputs/tar.py
@@ -16,7 +16,52 @@ if TYPE_CHECKING:
     from dissect.target.filesystem import FilesystemEntry
 
 TAR_COMPRESSION_METHODS = {"gzip": "gz", "bzip2": "bz2", "xz": "xz"}
+
 log = getLogger(__name__)
+
+
+def copyfileobj(
+    src: BinaryIO,
+    dst: BinaryIO,
+    length: int | None = None,
+    bufsize: int | None = None,
+    name: str = "",
+) -> None:
+    """Copy length bytes from fileobj src to fileobj dst.
+       If length is None, copy the entire content.
+       Inlined from the Python 3.13 function `tarfile.copyfileobj`, 
+       patched to pad a short read with NUL bytes instead of raising.
+    """
+    bufsize = bufsize or 16 * 1024
+    if length == 0:
+        return
+    if length is None:
+        shutil.copyfileobj(src, dst, bufsize)
+        return
+
+    padded = 0
+
+    blocks, remainder = divmod(length, bufsize)
+    for b in range(blocks):  # noqa: B007
+        buf = src.read(bufsize)
+        if len(buf) < bufsize:
+            # PATCH: pad the data instead of raising an exception
+            padded += bufsize - len(buf)
+            buf += tarfile.NUL * (bufsize - len(buf))
+        dst.write(buf)
+
+    if remainder != 0:
+        buf = src.read(remainder)
+        if len(buf) < remainder:
+            # PATCH: pad the data instead of raising an exception
+            padded += remainder - len(buf)
+            buf += tarfile.NUL * (remainder - len(buf))
+        dst.write(buf)
+
+    if padded:
+        log.warning("File %s shrank while reading, padded %d of %d byte(s) with NUL", name, padded, length)
+
+    return
 
 
 class TarOutput(Output):
@@ -104,65 +149,29 @@ class TarOutput(Output):
             if stat:
                 info.mtime = stat.st_mtime
 
-        # Inline version of Python stdlib's tarfile.addfile & tarfile.copyfileobj,
-        # to allow for padding and more control over the tar file writing.
+        # Inlined from the Python 3.13 tarfile.TarFile.addfile, so that the patched copyfileobj
+        # above is used instead of the one from the stdlib
         self.tar._check("awx")
 
         if fh is None and info.isreg() and info.size != 0:
-            return
+            raise ValueError("fileobj not provided for non zero-size regular file")
 
         tarinfo = copy.copy(info)
 
-        saved_offset = self.tar.offset
-        saved_filepos = self.tar.fileobj.tell()
+        buf = tarinfo.tobuf(self.tar.format, self.tar.encoding, self.tar.errors)
+        self.tar.fileobj.write(buf)
+        self.tar.offset += len(buf)
+        bufsize = self.tar.copybufsize
+        # If there's data to follow, append it.
+        if fh is not None:
+            copyfileobj(fh, self.tar.fileobj, tarinfo.size, bufsize=bufsize, name=tarinfo.name)
+            blocks, remainder = divmod(tarinfo.size, tarfile.BLOCKSIZE)
+            if remainder > 0:
+                self.tar.fileobj.write(tarfile.NUL * (tarfile.BLOCKSIZE - remainder))
+                blocks += 1
+            self.tar.offset += blocks * tarfile.BLOCKSIZE
 
-        try:
-            buf = tarinfo.tobuf(self.tar.format, self.tar.encoding, self.tar.errors)
-            self.tar.fileobj.write(buf)
-            self.tar.offset += len(buf)
-
-            if fh is not None:
-                # Start of tarfile.copyfileobj
-                bufsize = self.tar.copybufsize or 16 * 1024
-                if tarinfo.size == 0:
-                    return
-                if tarinfo.size is None:
-                    shutil.copyfileobj(fh, self.tar.fileobj, bufsize)
-                    return
-
-                blocks, remainder = divmod(tarinfo.size, bufsize)
-                for _ in range(blocks):
-                    buf = fh.read(bufsize)
-                    if len(buf) < bufsize:
-                        # PATCH; instead of raising an exception, pad the data to the desired length
-                        buf += tarfile.NUL * (bufsize - len(buf))
-                    self.tar.fileobj.write(buf)
-
-                if remainder > 0:
-                    buf = fh.read(remainder)
-                    if len(buf) < remainder:
-                        # PATCH; instead of raising an exception, pad the data to the desired length
-                        buf += tarfile.NUL * (remainder - len(buf))
-                    self.tar.fileobj.write(buf)
-                # End of tarfile.copyfileobj
-
-                blocks, remainder = divmod(tarinfo.size, tarfile.BLOCKSIZE)
-                if remainder > 0:
-                    self.tar.fileobj.write(tarfile.NUL * (tarfile.BLOCKSIZE - remainder))
-                    blocks += 1
-                self.tar.offset += blocks * tarfile.BLOCKSIZE
-
-            self.tar.members.append(tarinfo)
-        except Exception:
-            log.warning(
-                "An error occurred while writing to the tar file. "
-                "Truncating to the last known good state (offset: %d).",
-                saved_filepos,
-            )
-            self.tar.fileobj.seek(saved_filepos)
-            self.tar.fileobj.truncate()
-            self.tar.offset = saved_offset
-            raise
+        self.tar.members.append(tarinfo)
 
     def close(self) -> None:
         """Closes the tar file."""

--- a/tests/test_outputs_tar.py
+++ b/tests/test_outputs_tar.py
@@ -82,7 +82,7 @@ def test_tar_output_race_condition_with_shrinking_file(tmp_path: Path, public_ke
 
     content = b"some text"
 
-    content_padded = content[:-5] + b"\x00" * 5
+    content_padded = content[:-5] + tarfile.NUL * 5
     file = ShrinkingFile(content)
 
     tar_output = TarOutput(tmp_path / "race.tar", encrypt=True, public_key=public_key)

--- a/tests/test_outputs_tar.py
+++ b/tests/test_outputs_tar.py
@@ -66,7 +66,7 @@ def test_tar_output_encrypt(mock_fs: VirtualFilesystem, public_key: bytes, tmp_p
         assert entry.open().read() == tar_file.extractfile(entry_name).read()
 
 
-def test_tar_output_race_condition_with_growing_file(tmp_path: Path, public_key: bytes) -> None:
+def test_tar_output_race_condition_with_shrinking_file(tmp_path: Path, public_key: bytes) -> None:
     class ShrinkingFile(io.BytesIO):
         """
         A file-like object that returns 5 bytes less than required.
@@ -101,3 +101,40 @@ def test_tar_output_race_condition_with_growing_file(tmp_path: Path, public_key:
         extracted = tar_file.extractfile(member).read()
         # The content should be padded with zeros to match the original size, despite the fact that the file shrunk
         assert extracted == content_padded
+
+
+def test_tar_output_race_condition_with_growing_file(tmp_path: Path, public_key: bytes) -> None:
+    class GrowingFile(io.BytesIO):
+        """
+        A file-like object that returns 3 extra bytes.
+        Simulates a file on disk that has grown in between the time of
+        determining the size and actually reading the data.
+        """
+
+        def __init__(self, data: bytes):
+            super().__init__(data)
+
+        def read(self, size: int) -> bytes:
+            return super().read(size) + b"FOX"
+
+    content = b"some text"
+
+    file = GrowingFile(content)
+
+    tar_output = TarOutput(tmp_path / "race.tar", encrypt=True, public_key=public_key)
+    tar_output.write("file.log", file)
+    tar_output.close()
+    file.close()
+
+    encrypted_stream = EncryptedFile(tar_output.path.open("rb"), Path("tests/_data/private_key.pem"))
+    decrypted_path = tmp_path / "decrypted.tar"
+
+    # Direct streaming is not an option because tarfile needs seek when reading from encrypted files directly
+    Path(decrypted_path).write_bytes(encrypted_stream.read())
+
+    with tarfile.open(name=decrypted_path, mode="r") as tar_file:
+        member = tar_file.getmember("file.log")
+        extracted = tar_file.extractfile(member).read()
+        # The content should match the original content, without the extra bytes
+        # because the file was read with the original size
+        assert extracted == content

--- a/tests/test_outputs_tar.py
+++ b/tests/test_outputs_tar.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -63,3 +64,40 @@ def test_tar_output_encrypt(mock_fs: VirtualFilesystem, public_key: bytes, tmp_p
 
     with tarfile.open(name=decrypted_path, mode="r") as tar_file:
         assert entry.open().read() == tar_file.extractfile(entry_name).read()
+
+
+def test_tar_output_race_condition_with_growing_file(tmp_path: Path, public_key: bytes) -> None:
+    class ShrinkingFile(io.BytesIO):
+        """
+        A file-like object that returns 5 bytes less than required.
+        Simulates a file on disk that has shrunk in between the time of
+        determining the size and actually reading the data.
+        """
+
+        def __init__(self, data: bytes):
+            super().__init__(data)
+
+        def read(self, size: int) -> bytes:
+            return super().read(size - 5)
+
+    content = b"some text"
+
+    content_padded = content[:-5] + b"\x00" * 5
+    file = ShrinkingFile(content)
+
+    tar_output = TarOutput(tmp_path / "race.tar", encrypt=True, public_key=public_key)
+    tar_output.write("file.log", file)
+    tar_output.close()
+    file.close()
+
+    encrypted_stream = EncryptedFile(tar_output.path.open("rb"), Path("tests/_data/private_key.pem"))
+    decrypted_path = tmp_path / "decrypted.tar"
+
+    # Direct streaming is not an option because tarfile needs seek when reading from encrypted files directly
+    Path(decrypted_path).write_bytes(encrypted_stream.read())
+
+    with tarfile.open(name=decrypted_path, mode="r") as tar_file:
+        member = tar_file.getmember("file.log")
+        extracted = tar_file.extractfile(member).read()
+        # The content should be padded with zeros to match the original size, despite the fact that the file shrunk
+        assert extracted == content_padded

--- a/tests/test_outputs_tar.py
+++ b/tests/test_outputs_tar.py
@@ -68,12 +68,6 @@ def test_tar_output_encrypt(mock_fs: VirtualFilesystem, public_key: bytes, tmp_p
 
 def test_tar_output_race_condition_with_shrinking_file(tmp_path: Path, public_key: bytes) -> None:
     class ShrinkingFile(io.BytesIO):
-        """
-        A file-like object that returns 5 bytes less than required.
-        Simulates a file on disk that has shrunk in between the time of
-        determining the size and actually reading the data.
-        """
-
         def __init__(self, data: bytes):
             super().__init__(data)
 
@@ -105,12 +99,6 @@ def test_tar_output_race_condition_with_shrinking_file(tmp_path: Path, public_ke
 
 def test_tar_output_race_condition_with_growing_file(tmp_path: Path, public_key: bytes) -> None:
     class GrowingFile(io.BytesIO):
-        """
-        A file-like object that returns 3 extra bytes.
-        Simulates a file on disk that has grown in between the time of
-        determining the size and actually reading the data.
-        """
-
         def __init__(self, data: bytes):
             super().__init__(data)
 
@@ -138,3 +126,48 @@ def test_tar_output_race_condition_with_growing_file(tmp_path: Path, public_key:
         # The content should match the original content, without the extra bytes
         # because the file was read with the original size
         assert extracted == content
+
+
+def test_tar_output_exception_rollback(tmp_path: Path) -> None:
+    """Test that tar file is properly truncated when an exception occurs during writing."""
+
+    class FailingFile(io.BytesIO):
+        def __init__(self, data: bytes, fail_after_bytes: int = 5):
+            super().__init__(data)
+            self.fail_after_bytes = fail_after_bytes
+            self.bytes_read = 0
+
+        def read(self, size: int) -> bytes:
+            data = super().read(size)
+            self.bytes_read += len(data)
+            if self.bytes_read > self.fail_after_bytes:
+                raise IOError("Simulated I/O error during file read")
+            return data
+
+    content = b"This is some test content that will fail during reading"
+    failing_file = FailingFile(content, fail_after_bytes=5)
+
+    tar_output = TarOutput(tmp_path / "test.tar")
+
+    successful_file = io.BytesIO(b"dissectftw")
+    tar_output.write("successful_file.txt", successful_file)
+
+    file_size_before_failure = tar_output.tar.fileobj.tell()
+    members_count_before = len(tar_output.tar.members)
+
+    # Attempt to write the failing file
+    with pytest.raises(IOError, match="Simulated I/O error during file read"):
+        tar_output.write("failing_file.txt", failing_file, size=len(content))
+
+    # Verify that the tar file was truncated back to its state before the failed write
+    assert tar_output.tar.fileobj.tell() == file_size_before_failure
+    assert len(tar_output.tar.members) == members_count_before
+
+    tar_output.close()
+
+    # Verify the tar file can still be opened and contains only the successful entry
+    with tarfile.open(tar_output.path) as tar_file:
+        members = tar_file.getmembers()
+        assert len(members) == 1
+        assert members[0].name == "successful_file.txt"
+        assert tar_file.extractfile("successful_file.txt").read() == b"dissectftw"

--- a/tests/test_outputs_tar.py
+++ b/tests/test_outputs_tar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -67,6 +68,8 @@ def test_tar_output_encrypt(mock_fs: VirtualFilesystem, public_key: bytes, tmp_p
 
 
 def test_tar_output_race_condition_with_shrinking_file(tmp_path: Path, public_key: bytes) -> None:
+    """Test that the tar output correctly handles a file that shrinks while being read."""
+
     class ShrinkingFile(io.BytesIO):
         def __init__(self, data: bytes):
             super().__init__(data)
@@ -98,6 +101,8 @@ def test_tar_output_race_condition_with_shrinking_file(tmp_path: Path, public_ke
 
 
 def test_tar_output_race_condition_with_growing_file(tmp_path: Path, public_key: bytes) -> None:
+    """Test that the tar output correctly handles a file that grows while being read."""
+
     class GrowingFile(io.BytesIO):
         def __init__(self, data: bytes):
             super().__init__(data)
@@ -128,7 +133,7 @@ def test_tar_output_race_condition_with_growing_file(tmp_path: Path, public_key:
         assert extracted == content
 
 
-def test_tar_output_exception_rollback(tmp_path: Path) -> None:
+def test_tar_output_exception_rollback(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     """Test that tar file is properly truncated when an exception occurs during writing."""
 
     class FailingFile(io.BytesIO):
@@ -154,10 +159,18 @@ def test_tar_output_exception_rollback(tmp_path: Path) -> None:
 
     file_size_before_failure = tar_output.tar.fileobj.tell()
     members_count_before = len(tar_output.tar.members)
-
-    # Attempt to write the failing file
-    with pytest.raises(IOError, match="Simulated I/O error during file read"):
+    with (
+        caplog.at_level(logging.WARNING, logger="acquire.outputs.tar"),
+        pytest.raises(IOError, match="Simulated I/O error during file read"),
+    ):
+        # Attempt to write the failing file
         tar_output.write("failing_file.txt", failing_file, size=len(content))
+
+    # Check that a warning was logged about the error and the rollback
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message == (
+        "An error occurred while writing to the tar file. Truncating to the last known good state (offset: 1024)."
+    )
 
     # Verify that the tar file was truncated back to its state before the failed write
     assert tar_output.tar.fileobj.tell() == file_size_before_failure

--- a/tests/test_outputs_tar.py
+++ b/tests/test_outputs_tar.py
@@ -67,120 +67,48 @@ def test_tar_output_encrypt(mock_fs: VirtualFilesystem, public_key: bytes, tmp_p
         assert entry.open().read() == tar_file.extractfile(entry_name).read()
 
 
-def test_tar_output_race_condition_with_shrinking_file(tmp_path: Path, public_key: bytes) -> None:
-    """Test that the tar output correctly handles a file that shrinks while being read."""
+def test_tar_output_shrinking_file(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Test that a file that shrinks while being read is padded to its advertised size."""
 
     class ShrinkingFile(io.BytesIO):
-        def __init__(self, data: bytes):
-            super().__init__(data)
+        """Advertises more bytes than it can actually deliver."""
 
-        def read(self, size: int) -> bytes:
-            return super().read(size - 5)
+    # Larger than the copy buffer, so both the block loop and the remainder are exercised
+    size = (16 * 1024) + 100
+    file = ShrinkingFile(b"A" * 200)
 
-    content = b"some text"
+    tar_output = TarOutput(tmp_path / "shrink.tar")
 
-    content_padded = content[:-5] + tarfile.NUL * 5
-    file = ShrinkingFile(content)
+    with caplog.at_level(logging.WARNING, logger="acquire.outputs.tar"):
+        tar_output.write("shrunk.bin", file, size=size)
 
-    tar_output = TarOutput(tmp_path / "race.tar", encrypt=True, public_key=public_key)
-    tar_output.write("file.log", file)
-    tar_output.close()
-    file.close()
-
-    encrypted_stream = EncryptedFile(tar_output.path.open("rb"), Path("tests/_data/private_key.pem"))
-    decrypted_path = tmp_path / "decrypted.tar"
-
-    # Direct streaming is not an option because tarfile needs seek when reading from encrypted files directly
-    Path(decrypted_path).write_bytes(encrypted_stream.read())
-
-    with tarfile.open(name=decrypted_path, mode="r") as tar_file:
-        member = tar_file.getmember("file.log")
-        extracted = tar_file.extractfile(member).read()
-        # The content should be padded with zeros to match the original size, despite the fact that the file shrunk
-        assert extracted == content_padded
-
-
-def test_tar_output_race_condition_with_growing_file(tmp_path: Path, public_key: bytes) -> None:
-    """Test that the tar output correctly handles a file that grows while being read."""
-
-    class GrowingFile(io.BytesIO):
-        def __init__(self, data: bytes):
-            super().__init__(data)
-
-        def read(self, size: int) -> bytes:
-            return super().read(size) + b"FOX"
-
-    content = b"some text"
-
-    file = GrowingFile(content)
-
-    tar_output = TarOutput(tmp_path / "race.tar", encrypt=True, public_key=public_key)
-    tar_output.write("file.log", file)
-    tar_output.close()
-    file.close()
-
-    encrypted_stream = EncryptedFile(tar_output.path.open("rb"), Path("tests/_data/private_key.pem"))
-    decrypted_path = tmp_path / "decrypted.tar"
-
-    # Direct streaming is not an option because tarfile needs seek when reading from encrypted files directly
-    Path(decrypted_path).write_bytes(encrypted_stream.read())
-
-    with tarfile.open(name=decrypted_path, mode="r") as tar_file:
-        member = tar_file.getmember("file.log")
-        extracted = tar_file.extractfile(member).read()
-        # The content should match the original content, without the extra bytes
-        # because the file was read with the original size
-        assert extracted == content
-
-
-def test_tar_output_exception_rollback(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    """Test that tar file is properly truncated when an exception occurs during writing."""
-
-    class FailingFile(io.BytesIO):
-        def __init__(self, data: bytes, fail_after_bytes: int = 5):
-            super().__init__(data)
-            self.fail_after_bytes = fail_after_bytes
-            self.bytes_read = 0
-
-        def read(self, size: int) -> bytes:
-            data = super().read(size)
-            self.bytes_read += len(data)
-            if self.bytes_read > self.fail_after_bytes:
-                raise IOError("Simulated I/O error during file read")
-            return data
-
-    content = b"This is some test content that will fail during reading"
-    failing_file = FailingFile(content, fail_after_bytes=5)
-
-    tar_output = TarOutput(tmp_path / "test.tar")
-
-    successful_file = io.BytesIO(b"dissectftw")
-    tar_output.write("successful_file.txt", successful_file)
-
-    file_size_before_failure = tar_output.tar.fileobj.tell()
-    members_count_before = len(tar_output.tar.members)
-    with (
-        caplog.at_level(logging.WARNING, logger="acquire.outputs.tar"),
-        pytest.raises(IOError, match="Simulated I/O error during file read"),
-    ):
-        # Attempt to write the failing file
-        tar_output.write("failing_file.txt", failing_file, size=len(content))
-
-    # Check that a warning was logged about the error and the rollback
-    assert len(caplog.records) == 1
-    assert caplog.records[0].message == (
-        "An error occurred while writing to the tar file. Truncating to the last known good state (offset: 1024)."
-    )
-
-    # Verify that the tar file was truncated back to its state before the failed write
-    assert tar_output.tar.fileobj.tell() == file_size_before_failure
-    assert len(tar_output.tar.members) == members_count_before
-
+    # Write a second entry, to make sure the padding kept the archive offset in sync
+    tar_output.write("after.bin", io.BytesIO(b"written after the shrunk file"))
     tar_output.close()
 
-    # Verify the tar file can still be opened and contains only the successful entry
+    assert [record.message for record in caplog.records] == [
+        f"File shrunk.bin shrank while reading, padded {size - 200} of {size} byte(s) with NUL"
+    ]
+
     with tarfile.open(tar_output.path) as tar_file:
-        members = tar_file.getmembers()
-        assert len(members) == 1
-        assert members[0].name == "successful_file.txt"
-        assert tar_file.extractfile("successful_file.txt").read() == b"dissectftw"
+        assert tar_file.getnames() == ["shrunk.bin", "after.bin"]
+        assert tar_file.extractfile("shrunk.bin").read() == b"A" * 200 + tarfile.NUL * (size - 200)
+        assert tar_file.extractfile("after.bin").read() == b"written after the shrunk file"
+
+
+def test_tar_output_no_padding_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Test that files that are read in full are written without a padding warning."""
+    tar_output = TarOutput(tmp_path / "exact.tar")
+
+    with caplog.at_level(logging.WARNING, logger="acquire.outputs.tar"):
+        tar_output.write("exact.bin", io.BytesIO(b"A" * ((16 * 1024) + 100)))
+        tar_output.write("empty.bin", io.BytesIO(b""))
+
+    tar_output.close()
+
+    assert caplog.records == []
+
+    with tarfile.open(tar_output.path) as tar_file:
+        assert tar_file.getnames() == ["exact.bin", "empty.bin"]
+        assert tar_file.extractfile("exact.bin").read() == b"A" * ((16 * 1024) + 100)
+        assert tar_file.extractfile("empty.bin").read() == b""


### PR DESCRIPTION
Fixes an issue where a `.tar` output file would contain inconsistencies with regards to expected and actual file size of the included files.

In some cases, a file on disk can report a size of X bytes, but at the time of actually reading X bytes from the file, less than X bytes are actually available in the file (a short read). Acquire would report these issues as `OSError` in the resulting Acquisition log file, because the Python stdlib `tarfile.py` handles it that way. Data may however already be written to the destination archive at that point. 

Afterwards, Acquire continues to add new files to the archive. When trying to untar the file using `tar -xvf <FILE>` this would show as a `tar: Skipping to next header` error and finally, the process exists with a nonzero exit code.

Included a test case which simulates a file that actually returns less bytes than its reported size, to test this case.