### PR TITLE
Skip collection of large sparse files with tar outputs

### DIFF
--- a/acquire/outputs/tar.py
+++ b/acquire/outputs/tar.py
@@ -4,6 +4,8 @@ import io
 import tarfile
 from typing import TYPE_CHECKING, BinaryIO
 
+from dissect.target.filesystems.ntfs import NtfsFilesystem
+
 from acquire.crypt import EncryptedStream
 from acquire.outputs.base import Output
 
@@ -11,7 +13,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from dissect.target.filesystem import FilesystemEntry
-
 TAR_COMPRESSION_METHODS = {"gzip": "gz", "bzip2": "bz2", "xz": "xz"}
 
 
@@ -100,7 +101,9 @@ class TarOutput(Output):
             if stat:
                 info.mtime = stat.st_mtime
                 if (
-                    stat.st_blksize
+                    # Skip NTFS filesystems as st_blksize and st_blocks are not reliable
+                    not isinstance(entry.fs, NtfsFilesystem)
+                    and stat.st_blksize
                     and stat.st_blocks
                     and stat.st_size
                     and stat.st_size - (stat.st_blksize * stat.st_blocks) > stat.st_blksize

--- a/acquire/outputs/tar.py
+++ b/acquire/outputs/tar.py
@@ -99,6 +99,14 @@ class TarOutput(Output):
 
             if stat:
                 info.mtime = stat.st_mtime
+                if (
+                    stat.st_blksize
+                    and stat.st_blocks
+                    and stat.st_size
+                    and stat.st_size - (stat.st_blksize * stat.st_blocks) > stat.st_blksize
+                    and stat.st_size > 10 * 1024**3
+                ):  # 10 GB threshold
+                    raise Exception("Skipping large (>10GB) sparse file.")  # noqa: TRY002
 
         self.tar.addfile(info, fh)
 

--- a/tests/test_outputs_tar.py
+++ b/tests/test_outputs_tar.py
@@ -68,32 +68,36 @@ def test_tar_output_encrypt(mock_fs: VirtualFilesystem, public_key: bytes, tmp_p
 def test_tar_output_collector_skip_large_sparse(tmp_path: Path) -> None:
     # Create a temporary sparse file
     sparse_file_path = tmp_path / "sparse_file"
-    with sparse_file_path.open("wb") as f:
-        f.seek(11 * 1024**3)  # Seek to 11GB
-        f.write(b"FOX")
+    try:
+        with sparse_file_path.open("wb") as f:
+            f.seek(11 * 1024**3)  # Seek to 11GB
+            f.write(b"FOX")
 
-    fs = VirtualFilesystem(case_sensitive=False)
-    fs.makedirs("/var/log/")
-    fs.map_file("/var/log/lastlog", sparse_file_path)
-    fs.map_file_entry("/var/log/henk1", VirtualFile(fs, "henk1", io.BytesIO(b"content")))
-    fs.map_file_entry("/var/log/henk2", VirtualFile(fs, "henk2", io.BytesIO(b"content")))
+        fs = VirtualFilesystem(case_sensitive=False)
+        fs.makedirs("/var/log/")
+        fs.map_file("/var/log/lastlog", sparse_file_path)
+        fs.map_file_entry("/var/log/henk1", VirtualFile(fs, "henk1", io.BytesIO(b"content")))
+        fs.map_file_entry("/var/log/henk2", VirtualFile(fs, "henk2", io.BytesIO(b"content")))
 
-    target = Target()
-    target.fs.mount("/", fs)
-    target.filesystems.add(fs)
-    target.os = "fake"
+        target = Target()
+        target.fs.mount("/", fs)
+        target.filesystems.add(fs)
+        target.os = "fake"
 
-    output_tar = tmp_path / "output.tar.gz"
+        output_tar = tmp_path / "output.tar.gz"
 
-    collector = Collector(target, TarOutput(output_tar))
-    # While doing this, the sparse file will error out due to size threshold
-    collector.collect([[ArtifactType.DIR, "/var/log/"]], "DUMMY")
-    collector.close()
+        collector = Collector(target, TarOutput(output_tar))
+        # While doing this, the sparse file will error out due to size threshold
+        collector.collect([[ArtifactType.DIR, "/var/log/"]], "DUMMY")
+        collector.close()
 
-    with tarfile.open(name=output_tar, mode="r") as tar_file:
-        assert len(tar_file.getnames()) == 2, "Only two files should be present in the tar."
-        assert "lastlog" not in tar_file.getnames(), "Sparse file should be skipped due to size threshold."
-        assert tar_file.getmember("fs/var/log/henk1")
-        assert tar_file.getmember("fs/var/log/henk2")
-        with pytest.raises(KeyError):
-            tar_file.getmember("fs/var/log/lastlog")
+        with tarfile.open(name=output_tar, mode="r") as tar_file:
+            assert len(tar_file.getnames()) == 2, "Only two files should be present in the tar."
+            assert "lastlog" not in tar_file.getnames(), "Sparse file should be skipped due to size threshold."
+            assert tar_file.getmember("fs/var/log/henk1")
+            assert tar_file.getmember("fs/var/log/henk2")
+            with pytest.raises(KeyError):
+                tar_file.getmember("fs/var/log/lastlog")
+    finally:
+        if sparse_file_path.exists():
+            sparse_file_path.unlink()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
Fixes #143 and possible collection of other large (>10GB) sparse files. Adding this to the `TarOutput` class since the Python stdlib `tarfile.py` does not ship with sparse file write support. If specific sparse files need to be collected, they should be treated as special cases just like the UsnJrnl file, as mentioned in ticket #143. This PR at least prevents the creation of huge `.tar` files; as mentioned we encountered tar files of ~500GB because of this.

Please let me know if the 10GB threshold is okay, or if we can set it to an even lower value.