### PR TITLE
Extend webserver collection

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -17,7 +17,7 @@ import urllib.parse
 import urllib.request
 import warnings
 from collections import defaultdict
-from itertools import chain, product
+from itertools import product
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, NamedTuple, NoReturn
 
@@ -878,7 +878,7 @@ class IIS(Module):
             DeprecationWarning,
             stacklevel=2,
         )
-        return WebserverLog.get_spec_additions(cls, target, cli_args)
+        return Webserver.get_spec_additions(cls, target, cli_args)
 
 
 @register_module("--webserver")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "dissect.cstruct>=4,<5",
-    "dissect.target>=3.24,<4",
+    "dissect.target>=3.25.dev,<4",  # TODO: update on release
 ]
 dynamic = ["version"]
 
@@ -47,7 +47,7 @@ full = [
 dev = [
     "acquire[full]",
     "dissect.cstruct>=4.0.dev,<5.0.dev",
-    "dissect.target[dev]>=3.24.dev,<4.0.dev",
+    "dissect.target[dev]>=3.25.dev,<4.0.dev",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
closes #139 

Testing on VMs with IIS,  Nginx and Caddy seems to work fine with an adjusted version of `dissect.target` [#1287](https://github.com/fox-it/dissect.target/pull/1287). 

```
- Collecting file C:/Windows/System32/LogFiles/HTTPERR/httperr1.log to: fs/C:/Windows/System32/LogFiles/HTTPERR/httperr1.log
- Collecting file C:/Windows/System32/LogFiles/HTTPERR/httperr1.log succeeded

- Collecting file /var/caddy/access.json to: fs/$rootfs$/var/caddy/access.json
- Collecting file /var/caddy/access.json succeeded
- Collecting file /root/access.log to: fs/$rootfs$/root/access.log
- Collecting file /root/access.log succeeded
```

The issue specifies that tests should be written. Do we still want that, even with the tests that are already there in `dissect.target`?
