### PR TITLE
Fix issue where setting gui.shard to 0

### DIFF
--- a/acquire/gui/base.py
+++ b/acquire/gui/base.py
@@ -51,7 +51,7 @@ class GUI:
     def shard(self, shard: int) -> None:
         """Sets the shard of the progress bar."""
         # Use this to 'refine' progress bar (i.e. assign a shard)
-        if shard > 100 or shard < 1:
+        if shard > 100 or shard < 0:
             raise GUIError("Shards have to be between 0-100")
         self._shard = shard
 


### PR DESCRIPTION
This occurs when the number of targets > 50/90
