### PR TITLE
feature: Add HitmanPro logs to AV module

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -1177,7 +1177,6 @@ class AV(Module):
         ("path", "sysvol/ProgramData/Microsoft/Windows Defender/Scans/History/Service/Detection.log"),
         # Microsoft Safety Scanner
         ("path", "sysvol/Windows/Debug/msert.log"),
-
         # Sophos Hitman pro
         ("path", "sysvol/ProgramData/HitmanPro/Logs/"),
         ("path", "sysvol/ProgramData/HitmanPro.Alert/Logs/"),


### PR DESCRIPTION
This pull request adds support for collecting logs and database files from Sophos HitmanPro and HitmanPro.Alert in the `AV` module:

* Added new paths for Sophos HitmanPro logs (`sysvol/ProgramData/HitmanPro/Logs/` and `sysvol/ProgramData/HitmanPro/excalibur.db`) and HitmanPro.Alert logs (`sysvol/ProgramData/HitmanPro.Alert/Logs/` and `sysvol/ProgramData/HitmanPro.Alert/excalibur.db`) to the `AV` module in `acquire/acquire.py`.