### PR TITLE
Implicit set --compress when specifying --compress-method

### DIFF
--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -371,6 +371,9 @@ def check_and_set_acquire_args(
             raise ValueError(
                 f"Invalid compression method for tar, allowed are: {', '.join(TAR_COMPRESSION_METHODS.keys())}"
             )
+    else:
+        if args.compress_method:
+            raise ValueError("--compress-method can only be used when --compress is set")
 
     if args.keychain_file:
         keychain.register_keychain_file(args.keychain_file)

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -371,9 +371,9 @@ def check_and_set_acquire_args(
             raise ValueError(
                 f"Invalid compression method for tar, allowed are: {', '.join(TAR_COMPRESSION_METHODS.keys())}"
             )
-    else:
-        if args.compress_method:
-            raise ValueError("--compress-method can only be used when --compress is set")
+
+    if args.compress_method and not args.compress:
+        args.compress = True
 
     if args.keychain_file:
         keychain.register_keychain_file(args.keychain_file)

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -366,6 +366,9 @@ def check_and_set_acquire_args(
             raise ValueError(
                 f"Invalid compression method for tar, allowed are: {', '.join(TAR_COMPRESSION_METHODS.keys())}"
             )
+    else:
+        if args.compress_method:
+            raise ValueError("--compress-method can only be used when --compress is set")
 
     if args.keychain_file:
         keychain.register_keychain_file(args.keychain_file)

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -366,9 +366,9 @@ def check_and_set_acquire_args(
             raise ValueError(
                 f"Invalid compression method for tar, allowed are: {', '.join(TAR_COMPRESSION_METHODS.keys())}"
             )
-    else:
-        if args.compress_method:
-            raise ValueError("--compress-method can only be used when --compress is set")
+
+    if args.compress_method and not args.compress:
+        args.compress = True
 
     if args.keychain_file:
         keychain.register_keychain_file(args.keychain_file)


### PR DESCRIPTION
When specifying `--compress-method` without `--compress` the first argument is ignored. This PR adds a quick check to see that you always specify `--compress` when you specify a method. There is no need to specify a method when the compression is not happing.
