### PR TITLE
Add --wait-exit option

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -2334,19 +2334,29 @@ VOLATILE = {
 }
 
 
-def exit_success(default_args: list[str]) -> NoReturn:
+def exit_success(args: argparse.Namespace) -> NoReturn:
+    default_args = args.config.get("arguments")
     log.info("Acquire finished successful")
     log.info("Arguments: %s", " ".join(sys.argv[1:]))
     log.info("Default Arguments: %s", " ".join(default_args))
     log.info("Exiting with status code 0 (SUCCESS)")
+
+    if args.wait_exit:
+        input("Press any key to exit...")
+
     sys.exit(0)
 
 
-def exit_failure(default_args: list[str]) -> NoReturn:
+def exit_failure(args: argparse.Namespace) -> NoReturn:
+    default_args = args.config.get("arguments")
     log.error("Acquire FAILED")
     log.error("Arguments: %s", " ".join(sys.argv[1:]))
     log.error("Default Arguments: %s", " ".join(default_args))
     log.error("Exiting with status code 1 (FAILURE)")
+
+    if args.wait_exit:
+        input("Press any key to exit...")
+
     sys.exit(1)
 
 
@@ -2494,9 +2504,9 @@ def main() -> None:
         log.exception("")
 
     if acquire_successful:
-        exit_success(args.config.get("arguments"))
+        exit_success(args)
     else:
-        exit_failure(args.config.get("arguments"))
+        exit_failure(args)
 
 
 def load_child(target: Target, child_path: Path) -> None:

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -185,7 +185,7 @@ def create_argument_parser(profiles: dict, volatile: dict, modules: dict) -> arg
     parser.add_argument("-K", "--keychain-file", type=Path, help="keychain file in CSV format")
     parser.add_argument("-Kv", "--keychain-value", help="passphrase, recovery key or key file path value")
 
-    parser.add_argument("--wait-exit", help="wait on exit, needs to press enter before closing", action="store_true")
+    parser.add_argument("--wait-exit", help="wait on exit, needs to press a key before closing", action="store_true")
 
     for module_cls in modules.values():
         for args, kwargs in module_cls.__cli_args__:

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -185,6 +185,8 @@ def create_argument_parser(profiles: dict, volatile: dict, modules: dict) -> arg
     parser.add_argument("-K", "--keychain-file", type=Path, help="keychain file in CSV format")
     parser.add_argument("-Kv", "--keychain-value", help="passphrase, recovery key or key file path value")
 
+    parser.add_argument("--wait-exit", help="wait on exit, needs to press enter before closing", action="store_true")
+
     for module_cls in modules.values():
         for args, kwargs in module_cls.__cli_args__:
             parser.add_argument(*args, **kwargs)


### PR DESCRIPTION
This PR adds an argument called `--wait-exit` which requires the user to press any key before exiting. This is mainly useful when using acquire by double clicking an compiled version. Currently we have to open the log file to see if something went wrong, now we can inspect the logs before the terminal window closes.