### PR TITLE
Implement Azure Upload

### DIFF
--- a/acquire/acquire.py
+++ b/acquire/acquire.py
@@ -48,6 +48,7 @@ from acquire.hashes import (
 )
 from acquire.log import get_file_handler, reconfigure_log_file, setup_logging
 from acquire.outputs import OUTPUTS
+from acquire.uploaders.azure import AzureStorage
 from acquire.uploaders.minio import MinIO
 from acquire.uploaders.plugin import upload_files_using_uploader
 from acquire.uploaders.plugin_registry import UploaderRegistry
@@ -2406,14 +2407,7 @@ def main() -> None:
             exit_success(args.config.get("arguments"))
         # From here onwards, the GUI will be locked and cannot be closed because we're acquiring
 
-        if files:
-            if args.output:
-                args.file = files
-            else:
-                args.upload = files
-                args.auto_upload = False
-
-        plugins_to_load = [("cloud", MinIO)]
+        plugins_to_load = [("cloud", MinIO), ("azure", AzureStorage)]
         upload_plugins = UploaderRegistry("acquire.plugins", plugins_to_load)
 
         check_and_set_acquire_args(args, upload_plugins)

--- a/acquire/uploaders/azure.py
+++ b/acquire/uploaders/azure.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from logging import getLogger
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from acquire.uploaders.plugin import UploaderPlugin
+
+if TYPE_CHECKING:
+    from azure.storage.blob import ContainerClient
+
+log = getLogger(__name__)
+
+
+class AzureStorage(UploaderPlugin):
+    def __init__(self, upload: dict[str, str], **kwargs: dict[str, Any]) -> None:
+        """An uploader plugin that uploads files to Azure Blob Storage using a container-level SAS URL.
+
+        Args:
+            upload: Contains the SAS URL and optional folder prefix to use for the transfer.
+
+        Raises:
+            ValueError: When the configuration is invalid.
+        """
+        self.sas_url = upload.get("sas_url")
+        self.folder = upload.get("folder", "").rstrip("/")
+
+        if not self.sas_url:
+            raise ValueError("Invalid Azure Storage upload configuration: sas_url is required")
+
+    def prepare_client(self, paths: list[Path], proxies: dict[str, str] | None = None) -> Any:
+        """Prepares an Azure ContainerClient used to upload files.
+
+        Args:
+            paths: The files to upload.
+            proxies: Not supported
+
+        Raises:
+            RuntimeError: When the azure-storage-blob module is not installed.
+        """
+        try:
+            from azure.storage.blob import ContainerClient  # noqa: PLC0415
+        except ImportError:
+            raise RuntimeError("Azure Storage upload module is not available. Install 'azure-storage-blob'.")
+
+        if proxies:
+            self.log.warning("Proxy configurations are not supported for Azure Storage uploads. Ignoring proxies.")
+
+        return ContainerClient.from_container_url(self.sas_url)
+
+    def upload_file(self, client: ContainerClient, path: Path) -> None:
+        """Uploads a single file to Azure Blob Storage.
+
+        Args:
+            client: The Azure ContainerClient to use for the upload.
+            path: The path of the file to upload.
+        """
+        destination_path = path.name
+        if self.folder:
+            destination_path = Path(self.folder) / path.name
+
+        with path.open("rb") as data:
+            client.upload_blob(name=str(destination_path), data=data, overwrite=True)
+
+    def finish(self, client: Any) -> None:
+        """Closes the Azure ContainerClient.
+
+        Args:
+            client: The Azure ContainerClient to close.
+        """
+        client.close()

--- a/acquire/utils.py
+++ b/acquire/utils.py
@@ -182,6 +182,54 @@ def create_argument_parser(profiles: dict, volatile: dict, modules: dict) -> arg
     )
     parser.add_argument("--no-proxy", action="store_true", help="don't autodetect proxies")
 
+    upload_group = parser.add_argument_group(
+        "upload options",
+        "Upload configuration — used together with --upload or --auto-upload. "
+        "Command-line values take precedence over values embedded in the config.",
+    )
+    upload_group.add_argument(
+        "--upload-mode",
+        dest="upload_mode",
+        metavar="MODE",
+        help="upload plugin to use (e.g. azure, cloud)",
+    )
+    upload_group.add_argument(
+        "--upload-sas-url",
+        dest="upload_sas_url",
+        metavar="URL",
+        help="Azure Storage container-level SAS URL",
+    )
+    upload_group.add_argument(
+        "--upload-folder",
+        dest="upload_folder",
+        metavar="FOLDER",
+        help="optional sub-folder / prefix inside the upload destination (Azure and MinIO)",
+    )
+    upload_group.add_argument(
+        "--upload-endpoint",
+        dest="upload_endpoint",
+        metavar="ENDPOINT",
+        help="MinIO endpoint (host:port)",
+    )
+    upload_group.add_argument(
+        "--upload-access-id",
+        dest="upload_access_id",
+        metavar="ACCESS_ID",
+        help="MinIO access ID",
+    )
+    upload_group.add_argument(
+        "--upload-access-key",
+        dest="upload_access_key",
+        metavar="ACCESS_KEY",
+        help="MinIO secret access key",
+    )
+    upload_group.add_argument(
+        "--upload-bucket",
+        dest="upload_bucket",
+        metavar="BUCKET",
+        help="MinIO bucket name",
+    )
+
     parser.add_argument("-K", "--keychain-file", type=Path, help="keychain file in CSV format")
     parser.add_argument("-Kv", "--keychain-value", help="passphrase, recovery key or key file path value")
 
@@ -324,6 +372,24 @@ def check_and_set_acquire_args(
         raise ValueError("only one of --upload or --auto-upload can be specified")
 
     if args.upload or args.auto_upload:
+        # Merge CLI-supplied upload args into the config dict.
+        # CLI values take precedence over anything embedded in config.py.
+        upload_config = dict(args.config.get("upload") or {})
+        cli_upload_fields = {
+            "mode": args.upload_mode,
+            "sas_url": args.upload_sas_url,
+            "folder": args.upload_folder,
+            "endpoint": args.upload_endpoint,
+            "access_id": args.upload_access_id,
+            "access_key": args.upload_access_key,
+            "bucket": args.upload_bucket,
+        }
+
+        for key, value in cli_upload_fields.items():
+            if value is not None:
+                upload_config[key] = value  # noqa: PERF403
+        args.config["upload"] = upload_config
+
         upload_mode = args.config.get("upload", {}).get("mode")
         if not upload_mode:
             raise ValueError("Uploading is not configured")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "dissect.cstruct>=4,<5",
     "dissect.target>=3.25,<4",
 ]
+
 dynamic = ["version"]
 
 [project.urls]
@@ -37,6 +38,7 @@ repository = "https://github.com/fox-it/acquire"
 
 [project.optional-dependencies]
 full = [
+    "azure-storage-blob",
     "minio",
     "pycryptodome",
     "requests",

--- a/tests/test_azure_uploader.py
+++ b/tests/test_azure_uploader.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from acquire.uploaders.azure import AzureStorage
+from acquire.uploaders.plugin import upload_files_using_uploader
+from acquire.uploaders.plugin_registry import UploaderRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+VALID_SAS_URL = "https://account.blob.core.windows.net/container?sv=2021-06-08&sig=abc"
+
+
+@pytest.fixture
+def plugin_registry() -> UploaderRegistry:
+    return UploaderRegistry("")
+
+
+@pytest.fixture
+def load_plugin(plugin_registry: UploaderRegistry) -> UploaderRegistry:
+    plugin_registry.register("azure", AzureStorage)
+    return plugin_registry
+
+
+@pytest.fixture
+def azure_plugin(load_plugin: UploaderRegistry) -> type[AzureStorage]:
+    return load_plugin.get("azure")
+
+
+@pytest.fixture
+def azure_instance(azure_plugin: type[AzureStorage]) -> AzureStorage:
+    return azure_plugin(upload={"sas_url": VALID_SAS_URL})
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"sas_url": VALID_SAS_URL},
+        {"sas_url": VALID_SAS_URL, "extra_field": "ignored"},
+    ],
+)
+def test_azure_inputs(azure_plugin: type[AzureStorage], arguments: dict) -> None:
+    instance = azure_plugin(upload=arguments)
+
+    assert instance.sas_url == VALID_SAS_URL
+    assert instance.folder == ""
+
+
+def test_azure_valueerror_missing_sas_url(azure_plugin: type[AzureStorage]) -> None:
+    """Empty sas_url raises ValueError."""
+    with pytest.raises(ValueError, match="sas_url is required"):
+        azure_plugin(upload={})
+
+
+def test_azure_valueerror_empty_sas_url(azure_plugin: type[AzureStorage]) -> None:
+    """Empty string sas_url raises ValueError."""
+    with pytest.raises(ValueError, match="sas_url is required"):
+        azure_plugin(upload={"sas_url": ""})
+
+
+def test_azure_folder_initialization(azure_plugin: Callable) -> None:
+    instance_nested = azure_plugin(upload={"sas_url": VALID_SAS_URL, "folder": "Uploads/sub"})
+    assert instance_nested.folder == "Uploads/sub"
+
+
+def test_prepare_client_no_module(azure_instance: AzureStorage) -> None:
+    """Raises RuntimeError when azure-storage-blob is not installed."""
+    with (
+        patch.dict("sys.modules", {"azure.storage.blob": None}),
+        pytest.raises(RuntimeError, match="Azure Storage upload module is not available"),
+    ):
+        azure_instance.prepare_client([])
+
+
+def _make_azure_module_mock() -> MagicMock:
+    """Creates a sys.modules mock for azure.storage.blob that includes the required package hierarchy."""
+    mock_blob_module = MagicMock()
+    mock_container_client = MagicMock()
+    mock_blob_module.ContainerClient = mock_container_client
+    return mock_blob_module, mock_container_client
+
+
+def test_prepare_client_returns_container_client(azure_instance: AzureStorage) -> None:
+    mock_blob_module, mock_container_client_cls = _make_azure_module_mock()
+    mock_client = MagicMock()
+    mock_container_client_cls.from_container_url.return_value = mock_client
+
+    module_patches = {
+        "azure": MagicMock(),
+        "azure.storage": MagicMock(),
+        "azure.storage.blob": mock_blob_module,
+    }
+    with patch.dict("sys.modules", module_patches):
+        client = azure_instance.prepare_client([Path("file.tar")])
+
+    mock_container_client_cls.from_container_url.assert_called_once_with(VALID_SAS_URL)
+    assert client is mock_client
+
+
+def test_upload_file_without_folder(azure_instance: AzureStorage) -> None:
+    mock_client = MagicMock()
+    test_path = Path("example.tar")
+
+    with patch.object(Path, "open", mock_open(read_data=b"data")):
+        azure_instance.upload_file(mock_client, test_path)
+
+    mock_client.upload_blob.assert_called_once()
+    call_kwargs = mock_client.upload_blob.call_args
+    assert call_kwargs.kwargs["name"] == "example.tar"
+    assert call_kwargs.kwargs["overwrite"] is True
+
+
+def test_upload_file_with_folder(azure_instance: AzureStorage) -> None:
+    mock_client = MagicMock()
+    test_path = Path("example.tar")
+    azure_instance.folder = "forensics/2026"
+
+    with patch.object(Path, "open", mock_open(read_data=b"data")):
+        azure_instance.upload_file(mock_client, test_path)
+
+    call_kwargs = mock_client.upload_blob.call_args
+    assert call_kwargs.kwargs["name"] == "forensics/2026/example.tar"
+
+
+def test_finish_closes_client(azure_instance: AzureStorage) -> None:
+    mock_client = MagicMock()
+    azure_instance.finish(mock_client)
+    mock_client.close.assert_called_once()
+
+
+def test_upload_files_integration(azure_instance: AzureStorage) -> None:
+    """Ensures upload_files_using_uploader calls the right lifecycle methods."""
+    mock_client = MagicMock()
+    azure_instance.prepare_client = MagicMock(return_value=mock_client)
+    azure_instance.upload_file = MagicMock()
+    azure_instance.finish = MagicMock()
+
+    upload_files_using_uploader(azure_instance, [Path("hello.tar")])
+
+    azure_instance.prepare_client.assert_called_once()
+    azure_instance.upload_file.assert_called_once_with(mock_client, Path("hello.tar"))
+    azure_instance.finish.assert_called_once_with(mock_client)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -194,6 +194,128 @@ def test_check_and_set_acquire_args_upload_auto_upload_fail(
 
 
 @pytest.mark.parametrize(
+    "arg_name",
+    [
+        "upload",
+        "auto_upload",
+    ],
+)
+def test_check_and_set_acquire_args_cli_upload_mode(arg_name: str) -> None:
+    """--upload-mode on the CLI overrides the mode in config."""
+    config = {}  # no upload config embedded
+    mock_upload_plugin = MagicMock()
+    upload_plugins = {"azure": mock_upload_plugin}
+
+    args = get_args(**{arg_name: True, "config": config, "upload_mode": "azure"})
+    check_and_set_acquire_args(args, upload_plugins)
+
+    mock_upload_plugin.assert_called_once()
+    assert args.config["upload"]["mode"] == "azure"
+
+
+@pytest.mark.parametrize(
+    "arg_name",
+    [
+        "upload",
+        "auto_upload",
+    ],
+)
+def test_check_and_set_acquire_args_cli_overrides_config_mode(arg_name: str) -> None:
+    """--upload-mode on the CLI takes precedence over an embedded config value."""
+    config = {"upload": {"mode": "cloud"}}
+    mock_upload_plugin = MagicMock()
+    upload_plugins = {"azure": mock_upload_plugin}
+
+    args = get_args(**{arg_name: True, "config": config, "upload_mode": "azure"})
+    check_and_set_acquire_args(args, upload_plugins)
+
+    assert args.config["upload"]["mode"] == "azure"
+
+
+@pytest.mark.parametrize(
+    "arg_name",
+    [
+        "upload",
+        "auto_upload",
+    ],
+)
+def test_check_and_set_acquire_args_cli_azure_fields(arg_name: str) -> None:
+    """Azure-specific CLI args are merged into the upload config."""
+    config = {"upload": {"mode": "azure"}}
+    mock_upload_plugin = MagicMock()
+    upload_plugins = {"azure": mock_upload_plugin}
+
+    sas_url = "https://account.blob.core.windows.net/container?sv=2021&sig=abc"
+    args = get_args(
+        **{
+            arg_name: True,
+            "config": config,
+            "upload_sas_url": sas_url,
+            "upload_folder": "foo",
+        }
+    )
+    check_and_set_acquire_args(args, upload_plugins)
+
+    assert args.config["upload"]["sas_url"] == sas_url
+    assert args.config["upload"]["folder"] == "foo"
+
+
+@pytest.mark.parametrize(
+    "arg_name",
+    [
+        "upload",
+        "auto_upload",
+    ],
+)
+def test_check_and_set_acquire_args_cli_minio_fields(arg_name: str) -> None:
+    """MinIO-specific CLI args are merged into the upload config."""
+    config = {"upload": {"mode": "cloud"}}
+    mock_upload_plugin = MagicMock()
+    upload_plugins = {"cloud": mock_upload_plugin}
+
+    args = get_args(
+        **{
+            arg_name: True,
+            "config": config,
+            "upload_endpoint": "minio.example.com:9000",
+            "upload_access_id": "myid",
+            "upload_access_key": "mykey",
+            "upload_bucket": "mybucket",
+            "upload_folder": "uploads",
+        }
+    )
+    check_and_set_acquire_args(args, upload_plugins)
+
+    upload_cfg = args.config["upload"]
+    assert upload_cfg["endpoint"] == "minio.example.com:9000"
+    assert upload_cfg["access_id"] == "myid"
+    assert upload_cfg["access_key"] == "mykey"
+    assert upload_cfg["bucket"] == "mybucket"
+    assert upload_cfg["folder"] == "uploads"
+
+
+@pytest.mark.parametrize(
+    "arg_name",
+    [
+        "upload",
+        "auto_upload",
+    ],
+)
+def test_check_and_set_acquire_args_config_not_overridden_when_cli_not_set(arg_name: str) -> None:
+    """Config values are preserved when the matching CLI args are not provided."""
+    config = {"upload": {"mode": "azure", "sas_url": "https://original-url", "folder": "original-folder"}}
+    mock_upload_plugin = MagicMock()
+    upload_plugins = {"azure": mock_upload_plugin}
+
+    # No upload_sas_url or upload_folder passed — defaults are None
+    args = get_args(**{arg_name: True, "config": config})
+    check_and_set_acquire_args(args, upload_plugins)
+
+    assert args.config["upload"]["sas_url"] == "https://original-url"
+    assert args.config["upload"]["folder"] == "original-folder"
+
+
+@pytest.mark.parametrize(
     ("children", "arg_name", "output"),
     [
         # Output without children to a directory


### PR DESCRIPTION
Azure Storage unfortunately does not provide a MinIO endpoint. This PR adds support for using Azure as upload target. It also adds the option to configure upload at runtime using CLI parameters. This way it can be used like this:

```
acquire -u --upload-sas-url <sas> --upload-folder <folder>
```